### PR TITLE
feat(gui): allow selecting system modules

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -15,6 +15,12 @@
   <div>
     <label>Rooms: <input id="rooms" type="number" value="8" min="1" /></label>
     <label>Seed: <input id="seed" type="text" /></label>
+    <label>System:
+      <select id="system">
+        <option value="generic">generic</option>
+        <option value="dfrpg">dfrpg</option>
+      </select>
+    </label>
     <button id="generate">Generate</button>
   </div>
   <pre id="map"></pre>

--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -5,17 +5,19 @@ import { loadSystemModule } from '@src/services/system-loader';
 async function generate(): Promise<void> {
   const roomsInput = document.getElementById('rooms') as HTMLInputElement;
   const seedInput = document.getElementById('seed') as HTMLInputElement;
+  const systemInput = document.getElementById('system') as HTMLSelectElement;
   const mapEl = document.getElementById('map') as HTMLElement;
   const inputEl = document.getElementById('inputs') as HTMLElement;
   const outputEl = document.getElementById('outputs') as HTMLElement;
 
   const rooms = parseInt(roomsInput.value, 10) || 8;
   const seed = seedInput.value || undefined;
+  const system = systemInput.value || 'generic';
 
   const opts = { rooms, seed };
-  inputEl.textContent = JSON.stringify(opts, null, 2);
+  inputEl.textContent = JSON.stringify({ ...opts, system }, null, 2);
   const base = buildDungeon(opts);
-  const sys = await loadSystemModule('generic');
+  const sys = await loadSystemModule(system);
   const enriched = await sys.enrich(base);
   mapEl.textContent = renderAscii(enriched);
   outputEl.textContent = JSON.stringify(enriched, null, 2);

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -14,6 +14,12 @@
   <div>
     <label>Rooms: <input id="rooms" type="number" value="8" min="1"></label>
     <label>Seed: <input id="seed" type="text"></label>
+    <label>System:
+      <select id="system">
+        <option value="generic">generic</option>
+        <option value="dfrpg">dfrpg</option>
+      </select>
+    </label>
     <button id="generate">Generate</button>
   </div>
   <pre id="map"></pre>

--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -5,17 +5,19 @@ import { loadSystemModule } from '../services/system-loader';
 async function generate(): Promise<void> {
   const roomsInput = document.getElementById('rooms') as HTMLInputElement;
   const seedInput = document.getElementById('seed') as HTMLInputElement;
+  const systemInput = document.getElementById('system') as HTMLSelectElement;
   const mapEl = document.getElementById('map') as HTMLElement;
   const inputEl = document.getElementById('inputs') as HTMLElement;
   const outputEl = document.getElementById('outputs') as HTMLElement;
 
   const rooms = parseInt(roomsInput.value, 10) || 8;
   const seed = seedInput.value || undefined;
+  const system = systemInput.value || 'generic';
 
   const opts = { rooms, seed };
-  inputEl.textContent = JSON.stringify(opts, null, 2);
+  inputEl.textContent = JSON.stringify({ ...opts, system }, null, 2);
   const base = buildDungeon(opts);
-  const sys = await loadSystemModule('generic');
+  const sys = await loadSystemModule(system);
   const enriched = await sys.enrich(base);
   mapEl.textContent = renderAscii(enriched);
   outputEl.textContent = JSON.stringify(enriched, null, 2);


### PR DESCRIPTION
## Summary
- add system dropdown to GUI for choosing between `generic` and `dfrpg`
- dynamically load the selected system when generating a dungeon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689abf4e2e04832fb25d1481922fdd47