### PR TITLE
feat: add svg and foundry exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,32 @@ The included `dfrpg` system module adds random monsters, traps, and treasure to 
 
 ## Quick Start
 
-1) Install Node.js LTS and pnpm (or npm).
-2) Install deps:
+1. Install Node.js LTS and pnpm (or npm).
+2. Install deps:
+
 ```bash
 pnpm install
 ```
-3) Run the CLI (examples):
+
+3. Run the CLI (examples):
+
 ```bash
 pnpm doa generate --rooms=10 --system=dfrpg
-pnpm doa generate --rooms=20
+pnpm doa generate --rooms=20 --svg > map.svg
+pnpm doa generate --rooms=15 --foundry > foundry.json
+pnpm doa generate --rooms=8 --ascii
 ```
-4) GUI:
+
+4. GUI:
+
 ```bash
 pnpm gui         # dev server with HMR
 pnpm gui:build   # production build
 pnpm gui:preview # then open http://localhost:3000/
 ```
-5) Run tests:
+
+5. Run tests:
+
 ```bash
 pnpm test
 ```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,29 +1,34 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import { buildDungeon } from '../services/assembler';
-import { loadSystemModule } from '../services/system-loader';
-import { renderAscii } from '../services/render';
+import { Command } from "commander";
+import { buildDungeon } from "../services/assembler";
+import { loadSystemModule } from "../services/system-loader";
+import { renderAscii, renderSvg } from "../services/render";
+import { exportFoundry } from "../services/foundry";
 
 const program = new Command();
-program
-  .name('doa')
-  .description('DungeonsOnAutomatic – modular dungeon generator')
-  .version('0.1.0');
+program.name("doa").description("DungeonsOnAutomatic – modular dungeon generator").version("0.1.0");
 
-program.command('generate')
-  .description('Generate a dungeon')
-  .option('--rooms <n>', 'number of rooms', (v) => parseInt(v, 10))
-  .option('--seed <seed>', 'random seed')
-  .option('--system <name>', 'system module to use (generic|dfrpg)', 'generic')
-  .option('--ascii', 'render an ASCII map instead of JSON output')
+program
+  .command("generate")
+  .description("Generate a dungeon")
+  .option("--rooms <n>", "number of rooms", (v) => parseInt(v, 10))
+  .option("--seed <seed>", "random seed")
+  .option("--system <name>", "system module to use (generic|dfrpg)", "generic")
+  .option("--ascii", "render an ASCII map instead of JSON output")
+  .option("--svg", "render an SVG map instead of JSON output")
+  .option("--foundry", "output FoundryVTT-compatible JSON")
   .action(async (opts) => {
     const d = buildDungeon({ rooms: opts.rooms, seed: opts.seed });
     const sys = await loadSystemModule(opts.system);
     const enriched = await sys.enrich(d);
-    if (opts.ascii) {
-      process.stdout.write(renderAscii(enriched) + '\n');
+    if (opts.svg) {
+      process.stdout.write(renderSvg(enriched) + "\n");
+    } else if (opts.ascii) {
+      process.stdout.write(renderAscii(enriched) + "\n");
+    } else if (opts.foundry) {
+      process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");
     } else {
-      process.stdout.write(JSON.stringify(enriched, null, 2) + '\n');
+      process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
     }
   });
 

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -1,26 +1,45 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>DOA Quick GUI</title>
-  <style>
-    body { font-family: monospace; padding: 1rem; }
-    label { margin-right: 0.5rem; }
-    pre { white-space: pre; border: 1px solid #ccc; padding: 0.5rem; margin-top: 1rem; }
-  </style>
-</head>
-<body>
-  <h1>Dungeon Generator</h1>
-  <div>
-    <label>Rooms: <input id="rooms" type="number" value="8" min="1"></label>
-    <label>Seed: <input id="seed" type="text"></label>
-    <button id="generate">Generate</button>
-  </div>
-  <pre id="map"></pre>
-  <h2>Input</h2>
-  <pre id="inputs"></pre>
-  <h2>Output</h2>
-  <pre id="outputs"></pre>
-  <script type="module" src="./main.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>DOA Quick GUI</title>
+    <style>
+      body {
+        font-family: monospace;
+        padding: 1rem;
+      }
+      label {
+        margin-right: 0.5rem;
+      }
+      pre {
+        white-space: pre;
+        border: 1px solid #ccc;
+        padding: 0.5rem;
+        margin-top: 1rem;
+      }
+      #map {
+        border: 1px solid #ccc;
+        padding: 0.5rem;
+        margin-top: 1rem;
+        display: inline-block;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Dungeon Generator</h1>
+    <div>
+      <label>Rooms: <input id="rooms" type="number" value="8" min="1" /></label>
+      <label>Seed: <input id="seed" type="text" /></label>
+      <button id="generate">Generate</button>
+      <a id="download-foundry" download="dungeon.json" style="margin-left: 1rem"
+        >Download Foundry JSON</a
+      >
+    </div>
+    <div id="map"></div>
+    <h2>Input</h2>
+    <pre id="inputs"></pre>
+    <h2>Output</h2>
+    <pre id="outputs"></pre>
+    <script type="module" src="./main.js"></script>
+  </body>
 </html>

--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -1,13 +1,15 @@
-import { buildDungeon } from '../services/assembler';
-import { renderAscii } from '../services/render';
-import { loadSystemModule } from '../services/system-loader';
+import { buildDungeon } from "../services/assembler";
+import { renderSvg } from "../services/render";
+import { exportFoundry } from "../services/foundry";
+import { loadSystemModule } from "../services/system-loader";
 
 async function generate(): Promise<void> {
-  const roomsInput = document.getElementById('rooms') as HTMLInputElement;
-  const seedInput = document.getElementById('seed') as HTMLInputElement;
-  const mapEl = document.getElementById('map') as HTMLElement;
-  const inputEl = document.getElementById('inputs') as HTMLElement;
-  const outputEl = document.getElementById('outputs') as HTMLElement;
+  const roomsInput = document.getElementById("rooms") as HTMLInputElement;
+  const seedInput = document.getElementById("seed") as HTMLInputElement;
+  const mapEl = document.getElementById("map") as HTMLElement;
+  const inputEl = document.getElementById("inputs") as HTMLElement;
+  const outputEl = document.getElementById("outputs") as HTMLElement;
+  const foundryLink = document.getElementById("download-foundry") as HTMLAnchorElement;
 
   const rooms = parseInt(roomsInput.value, 10) || 8;
   const seed = seedInput.value || undefined;
@@ -15,18 +17,21 @@ async function generate(): Promise<void> {
   const opts = { rooms, seed };
   inputEl.textContent = JSON.stringify(opts, null, 2);
   const base = buildDungeon(opts);
-  const sys = await loadSystemModule('generic');
+  const sys = await loadSystemModule("generic");
   const enriched = await sys.enrich(base);
-  mapEl.textContent = renderAscii(enriched);
+  mapEl.innerHTML = renderSvg(enriched);
   outputEl.textContent = JSON.stringify(enriched, null, 2);
+  const foundry = exportFoundry(enriched);
+  const blob = new Blob([JSON.stringify(foundry, null, 2)], { type: "application/json" });
+  foundryLink.href = URL.createObjectURL(blob);
 }
 
-document.getElementById('generate')?.addEventListener('click', () => {
-  generate().catch(err => {
+document.getElementById("generate")?.addEventListener("click", () => {
+  generate().catch((err) => {
     // log error to console and show message in UI
     console.error(err);
-    const mapEl = document.getElementById('map') as HTMLElement;
-    mapEl.textContent = 'Error generating dungeon';
+    const mapEl = document.getElementById("map") as HTMLElement;
+    mapEl.textContent = "Error generating dungeon";
   });
 });
 

--- a/src/services/foundry.ts
+++ b/src/services/foundry.ts
@@ -1,0 +1,64 @@
+import { Dungeon } from "../core/types";
+
+export interface FoundryWall {
+  c: [number, number, number, number];
+}
+
+export interface FoundryScene {
+  name: string;
+  walls: FoundryWall[];
+  width: number;
+  height: number;
+  grid: number;
+}
+
+/**
+ * Convert a dungeon into a simple FoundryVTT Scene JSON. Each room and
+ * corridor tile becomes floor space with surrounding walls. The scene uses a
+ * fixed grid size.
+ */
+export function exportFoundry(d: Dungeon, grid = 100): FoundryScene {
+  const cells: { x: number; y: number }[] = [];
+  for (const r of d.rooms) {
+    for (let y = r.y; y < r.y + r.h; y++) {
+      for (let x = r.x; x < r.x + r.w; x++) {
+        cells.push({ x, y });
+      }
+    }
+  }
+  for (const c of d.corridors) {
+    for (const p of c.path) cells.push(p);
+  }
+
+  const maxX = Math.max(0, ...cells.map((p) => p.x)) + 1;
+  const maxY = Math.max(0, ...cells.map((p) => p.y)) + 1;
+
+  const edges = new Set<string>();
+  const addEdge = (x1: number, y1: number, x2: number, y2: number) => {
+    const key = `${x1},${y1},${x2},${y2}`;
+    const rev = `${x2},${y2},${x1},${y1}`;
+    if (edges.has(rev)) edges.delete(rev);
+    else edges.add(key);
+  };
+
+  for (const cell of cells) {
+    const { x, y } = cell;
+    addEdge(x, y, x + 1, y);
+    addEdge(x + 1, y, x + 1, y + 1);
+    addEdge(x + 1, y + 1, x, y + 1);
+    addEdge(x, y + 1, x, y);
+  }
+
+  const walls: FoundryWall[] = Array.from(edges).map((e) => {
+    const [x1, y1, x2, y2] = e.split(",").map(Number);
+    return { c: [x1 * grid, y1 * grid, x2 * grid, y2 * grid] };
+  });
+
+  return {
+    name: "Generated Dungeon",
+    walls,
+    width: maxX * grid,
+    height: maxY * grid,
+    grid,
+  };
+}

--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -1,4 +1,4 @@
-import { Dungeon } from '../core/types';
+import { Dungeon } from "../core/types";
 
 /**
  * Render a simple ASCII map of the dungeon. Rooms are drawn with '#' borders
@@ -13,24 +13,64 @@ export function renderAscii(d: Dungeon): string {
   for (const c of d.corridors) {
     for (const p of c.path) points.push(p);
   }
-  const maxX = Math.max(0, ...points.map(p => p.x)) + 1;
-  const maxY = Math.max(0, ...points.map(p => p.y)) + 1;
-  const grid: string[][] = Array.from({ length: maxY }, () => Array(maxX).fill(' '));
+  const maxX = Math.max(0, ...points.map((p) => p.x)) + 1;
+  const maxY = Math.max(0, ...points.map((p) => p.y)) + 1;
+  const grid: string[][] = Array.from({ length: maxY }, () => Array(maxX).fill(" "));
 
   for (const r of d.rooms) {
     for (let y = r.y; y < r.y + r.h; y++) {
       for (let x = r.x; x < r.x + r.w; x++) {
         const border = x === r.x || x === r.x + r.w - 1 || y === r.y || y === r.y + r.h - 1;
-        grid[y][x] = border ? '#' : '.';
+        grid[y][x] = border ? "#" : ".";
       }
     }
   }
   for (const c of d.corridors) {
     for (const p of c.path) {
-      if (grid[p.y]?.[p.x] === ' ') grid[p.y][p.x] = '+';
+      if (grid[p.y]?.[p.x] === " ") grid[p.y][p.x] = "+";
     }
   }
-  return grid.map(row => row.join('')).join('\n');
+  return grid.map((row) => row.join("")).join("\n");
+}
+
+/**
+ * Render a very simple SVG representation of the dungeon. Rooms are drawn as
+ * stroked rectangles and corridor tiles are filled squares. The output is a
+ * standalone SVG string sized to the dungeon's extents.
+ */
+export function renderSvg(d: Dungeon): string {
+  const cell = 20; // pixel size of a single grid square
+  const points: { x: number; y: number }[] = [];
+  for (const r of d.rooms) {
+    points.push({ x: r.x + r.w, y: r.y + r.h });
+  }
+  for (const c of d.corridors) {
+    for (const p of c.path) points.push(p);
+  }
+  const maxX = Math.max(0, ...points.map((p) => p.x)) + 1;
+  const maxY = Math.max(0, ...points.map((p) => p.y)) + 1;
+  const width = maxX * cell;
+  const height = maxY * cell;
+  const parts: string[] = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+  ];
+
+  for (const c of d.corridors) {
+    for (const p of c.path) {
+      parts.push(
+        `<rect x="${p.x * cell}" y="${p.y * cell}" width="${cell}" height="${cell}" fill="white" stroke="none"/>`,
+      );
+    }
+  }
+
+  for (const r of d.rooms) {
+    parts.push(
+      `<rect x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="white" stroke="black"/>`,
+    );
+  }
+
+  parts.push("</svg>");
+  return parts.join("");
 }
 
 export default renderAscii;

--- a/tests/foundry-export.test.ts
+++ b/tests/foundry-export.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { buildDungeon } from "../src/services/assembler.js";
+import { exportFoundry } from "../src/services/foundry.js";
+
+describe("exportFoundry", () => {
+  it("creates a scene with walls", () => {
+    const d = buildDungeon({ rooms: 1, seed: "foundry" });
+    const scene = exportFoundry(d);
+    expect(scene.walls.length).toBeGreaterThan(0);
+    expect(scene.width).toBeGreaterThan(0);
+    expect(scene.height).toBeGreaterThan(0);
+  });
+});

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { buildDungeon } from "../src/services/assembler.js";
+import { renderSvg } from "../src/services/render.js";
+
+describe("renderSvg", () => {
+  it("produces svg markup", () => {
+    const d = buildDungeon({ rooms: 2, seed: "svg" });
+    const svg = renderSvg(d);
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg).toMatch(/<rect/);
+  });
+});


### PR DESCRIPTION
## Summary
- render dungeons as SVG maps and export FoundryVTT scenes
- add CLI flags and GUI support for SVG and Foundry exports
- document new output formats and provide unit tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689abf64d424832f8abb3dfa93b40952