### PR TITLE
feat(gui): add svg and foundry exports

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -8,6 +8,7 @@
     body { font-family: monospace; padding: 1rem; }
     label { margin-right: 0.5rem; }
     pre { white-space: pre; border: 1px solid #ccc; padding: 0.5rem; margin-top: 1rem; }
+    #map { border: 1px solid #ccc; padding: 0.5rem; margin-top: 1rem; display: inline-block; }
   </style>
 </head>
 <body>
@@ -22,8 +23,10 @@
       </select>
     </label>
     <button id="generate">Generate</button>
+    <a id="download-svg" download="dungeon.svg" style="margin-left: 1rem">Download SVG</a>
+    <a id="download-foundry" download="dungeon.json" style="margin-left: 1rem">Download Foundry JSON</a>
   </div>
-  <pre id="map"></pre>
+  <div id="map"></div>
   <h2>Input</h2>
   <pre id="inputs"></pre>
   <h2>Output</h2>

--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -1,5 +1,6 @@
 import { buildDungeon } from '@src/services/assembler';
-import { renderAscii } from '@src/services/render';
+import { renderSvg } from '@src/services/render';
+import { exportFoundry } from '@src/services/foundry';
 import { loadSystemModule } from '@src/services/system-loader';
 
 async function generate(): Promise<void> {
@@ -9,6 +10,8 @@ async function generate(): Promise<void> {
   const mapEl = document.getElementById('map') as HTMLElement;
   const inputEl = document.getElementById('inputs') as HTMLElement;
   const outputEl = document.getElementById('outputs') as HTMLElement;
+  const svgLink = document.getElementById('download-svg') as HTMLAnchorElement;
+  const foundryLink = document.getElementById('download-foundry') as HTMLAnchorElement;
 
   const rooms = parseInt(roomsInput.value, 10) || 8;
   const seed = seedInput.value || undefined;
@@ -19,8 +22,14 @@ async function generate(): Promise<void> {
   const base = buildDungeon(opts);
   const sys = await loadSystemModule(system);
   const enriched = await sys.enrich(base);
-  mapEl.textContent = renderAscii(enriched);
+  const svg = renderSvg(enriched);
+  mapEl.innerHTML = svg;
   outputEl.textContent = JSON.stringify(enriched, null, 2);
+  const svgBlob = new Blob([svg], { type: 'image/svg+xml' });
+  svgLink.href = URL.createObjectURL(svgBlob);
+  const foundry = exportFoundry(enriched);
+  const foundryBlob = new Blob([JSON.stringify(foundry, null, 2)], { type: 'application/json' });
+  foundryLink.href = URL.createObjectURL(foundryBlob);
 }
 
 document.getElementById('generate')?.addEventListener('click', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,24 +18,19 @@ program
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
-  .action(async (opts) => {
-    const d = buildDungeon({ rooms: opts.rooms, seed: opts.seed });
-    const sys = await loadSystemModule(opts.system);
-    const enriched = await sys.enrich(d, { sources: opts.source });
-    if (opts.svg) {
-      process.stdout.write(renderSvg(enriched) + "\n");
-    } else if (opts.ascii) {
-      process.stdout.write(renderAscii(enriched) + "\n");
-    } else if (opts.foundry) {
-      process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");
-    } else {
-      process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
-    }
-  });
-
-    } else {
-      process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
-    }
-  });
+    .action(async (opts) => {
+      const d = buildDungeon({ rooms: opts.rooms, seed: opts.seed });
+      const sys = await loadSystemModule(opts.system);
+      const enriched = await sys.enrich(d, { sources: opts.source });
+      if (opts.svg) {
+        process.stdout.write(renderSvg(enriched) + "\n");
+      } else if (opts.ascii) {
+        process.stdout.write(renderAscii(enriched) + "\n");
+      } else if (opts.foundry) {
+        process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");
+      } else {
+        process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
+      }
+    });
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary
- render dungeon maps as SVG in the GUI
- add download links for SVG and FoundryVTT JSON exports
- clean up duplicate code in CLI

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3adc9994832f80c4d68b5c1ac4e9