### PR TITLE
fix: enforce room spacing and corridor paths

### DIFF
--- a/src/services/rooms.ts
+++ b/src/services/rooms.ts
@@ -3,7 +3,10 @@ import { id, pick } from './random';
 
 const KINDS: Room['kind'][] = ['chamber', 'hall', 'cavern', 'lair', 'special'];
 
-/** Generate N non-overlapping rooms within a rectangular grid. */
+/** Generate N non-overlapping rooms within a rectangular grid.
+ * Rooms will have at least one tile of padding between them to leave space
+ * for corridors so they never touch or overlap.
+ */
 export function generateRooms(n: number, width = 80, height = 60, r: () => number): Room[] {
   const rooms: Room[] = [];
   let attempts = 0;
@@ -22,6 +25,15 @@ export function generateRooms(n: number, width = 80, height = 60, r: () => numbe
   return rooms;
 }
 
+/**
+ * Determine whether two rooms overlap or touch.  The extra +/-1 padding
+ * ensures there is always at least one tile gap between any two rooms.
+ */
 function overlaps(a: Room, b: Room): boolean {
-  return !(a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y);
+  return !(
+    a.x + a.w + 1 <= b.x ||
+    b.x + b.w + 1 <= a.x ||
+    a.y + a.h + 1 <= b.y ||
+    b.y + b.h + 1 <= a.y
+  );
 }

--- a/tests/corridors.test.ts
+++ b/tests/corridors.test.ts
@@ -10,6 +10,11 @@ describe('corridors', () => {
     const corridors = connectRooms(rooms);
     expect(corridors.length).toBe(rooms.length - 1);
 
+    // Each corridor should traverse at least one tile between rooms
+    for (const c of corridors) {
+      expect(c.path.length).toBeGreaterThan(1);
+    }
+
     const adj = new Map<string, string[]>();
     for (const c of corridors) {
       if (!adj.has(c.from)) adj.set(c.from, []);

--- a/tests/rooms.test.ts
+++ b/tests/rooms.test.ts
@@ -3,7 +3,13 @@ import { generateRooms } from '../src/services/rooms.js';
 import { rng } from '../src/services/random.js';
 
 function overlaps(a: {x:number;y:number;w:number;h:number}, b: {x:number;y:number;w:number;h:number}): boolean {
-  return !(a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y);
+  // Treat touching rooms as overlapping by adding a one-tile padding
+  return !(
+    a.x + a.w + 1 <= b.x ||
+    b.x + b.w + 1 <= a.x ||
+    a.y + a.h + 1 <= b.y ||
+    b.y + b.h + 1 <= a.y
+  );
 }
 
 describe('rooms', () => {


### PR DESCRIPTION
## Summary
- ensure rooms never overlap or touch by adding one-tile padding
- verify corridors traverse at least one tile between rooms
- extend tests to guard against overlapping rooms and missing corridors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3d153014832f93dbee855f32111f