### PR TITLE
feat: redesign key item service

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -37,11 +37,36 @@ export interface Treasure {
   valueHint?: string; // system-agnostic, e.g., 'minor', 'standard', 'major'
 }
 
+export enum PlacementRule {
+  REQUIRED = 'REQUIRED',
+  OPTIONAL = 'OPTIONAL',
+  HIDDEN = 'HIDDEN',
+  LOST = 'LOST',
+}
+
+export enum PlacementTarget {
+  MONSTER_LOOT = 'MONSTER_LOOT',
+  TREASURE_CHEST = 'TREASURE_CHEST',
+  ROOM_FEATURE = 'ROOM_FEATURE',
+  NPC_POSSESSION = 'NPC_POSSESSION',
+}
+
+export interface KeyItem {
+  id: ID;
+  doorId: ID;
+  name: string;
+  type: string;
+  placementRule: PlacementRule;
+  placementTarget: PlacementTarget;
+  locationId?: ID;
+}
+
 export interface Dungeon {
   seed: string;
   rooms: Room[];
   corridors: Corridor[];
   encounters?: Record<ID, { monsters?: Monster[]; traps?: Trap[]; treasure?: Treasure[] }>;
+  keyItems?: KeyItem[];
 }
 
 export interface SystemModule {

--- a/src/services/key-items.ts
+++ b/src/services/key-items.ts
@@ -1,0 +1,46 @@
+import { PlacementRule, PlacementTarget, type KeyItem } from '../core/types';
+
+class KeyItemService {
+  private items = new Map<string, KeyItem>();
+  private seq = 0;
+
+  generate_key(
+    doorId: string,
+    placementRule: PlacementRule,
+    placementTarget: PlacementTarget,
+  ): KeyItem {
+    const id = `key-${++this.seq}`;
+    const item: KeyItem = {
+      id,
+      doorId,
+      name: `Key for ${doorId}`,
+      type: 'key',
+      placementRule,
+      placementTarget,
+    };
+    this.items.set(id, item);
+    return item;
+  }
+
+  get_unplaced_keys(): KeyItem[] {
+    return Array.from(this.items.values()).filter(
+      (i) => !i.locationId && i.placementRule !== PlacementRule.LOST,
+    );
+  }
+
+  mark_as_placed(keyId: string, locationId: string): void {
+    const item = this.items.get(keyId);
+    if (item) {
+      item.locationId = locationId;
+    }
+  }
+
+  reset(): void {
+    this.items.clear();
+    this.seq = 0;
+  }
+}
+
+export const keyItemService = new KeyItemService();
+export { PlacementRule, PlacementTarget };
+export type { KeyItem };

--- a/tests/key-items.test.ts
+++ b/tests/key-items.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  keyItemService,
+  PlacementRule,
+  PlacementTarget,
+} from '../src/services/key-items.js';
+
+describe('key item service', () => {
+  beforeEach(() => {
+    keyItemService.reset();
+  });
+
+  it('generates and lists unplaced keys', () => {
+    const key = keyItemService.generate_key(
+      'door1',
+      PlacementRule.REQUIRED,
+      PlacementTarget.MONSTER_LOOT,
+    );
+    expect(keyItemService.get_unplaced_keys()).toEqual([key]);
+  });
+
+  it('marks keys as placed', () => {
+    const key = keyItemService.generate_key(
+      'door2',
+      PlacementRule.REQUIRED,
+      PlacementTarget.TREASURE_CHEST,
+    );
+    keyItemService.mark_as_placed(key.id, 'chest1');
+    expect(keyItemService.get_unplaced_keys()).toHaveLength(0);
+  });
+
+  it('ignores lost keys when listing unplaced', () => {
+    keyItemService.generate_key(
+      'door3',
+      PlacementRule.LOST,
+      PlacementTarget.MONSTER_LOOT,
+    );
+    expect(keyItemService.get_unplaced_keys()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce placement enums and richer `KeyItem` structure
- implement key item service with generation, placement tracking, and reset helpers
- validate key item workflow with new unit tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b46c40608832f85a68340294aebd7