### PR TITLE
feat: add fantasy door generator module

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,6 +17,12 @@ export interface Corridor {
   path: { x: number; y: number; }[]; // polyline grid path
 }
 
+export interface Door {
+  id: ID;
+  type: 'normal' | 'arch' | 'portcullis' | 'hole';
+  status: 'locked' | 'trapped' | 'barred' | 'jammed' | 'warded' | 'secret';
+}
+
 export interface Monster {
   name: string;
   sm?: number | null;

--- a/src/services/doors.ts
+++ b/src/services/doors.ts
@@ -1,0 +1,9 @@
+import { Door } from '../core/types';
+import { id, pick } from './random';
+
+export const DOOR_TYPES: Door['type'][] = ['normal', 'arch', 'portcullis', 'hole'];
+export const DOOR_STATUSES: Door['status'][] = ['locked', 'trapped', 'barred', 'jammed', 'warded', 'secret'];
+
+export function generateDoor(r: () => number): Door {
+  return { id: id('door'), type: pick(r, DOOR_TYPES), status: pick(r, DOOR_STATUSES) };
+}

--- a/tests/doors.test.ts
+++ b/tests/doors.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { generateDoor, DOOR_TYPES, DOOR_STATUSES } from '../src/services/doors.js';
+import { rng } from '../src/services/random.js';
+
+describe('doors', () => {
+  it('generateDoor produces valid types and statuses', () => {
+    const r = rng('doorTest');
+    const types = new Set<string>();
+    const statuses = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const d = generateDoor(r);
+      types.add(d.type);
+      statuses.add(d.status);
+    }
+    expect([...types].sort()).toEqual([...DOOR_TYPES].sort());
+    expect([...statuses].sort()).toEqual([...DOOR_STATUSES].sort());
+  });
+});


### PR DESCRIPTION
## Summary
- define Door type with enumerated forms and statuses
- implement door generator using random type and status pools
- cover door generation with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b461ed7fc832f94f053e6362cc434