### PR TITLE
feat: pathfinder with key item integration

### DIFF
--- a/src/services/key-items.ts
+++ b/src/services/key-items.ts
@@ -35,6 +35,12 @@ class KeyItemService {
     }
   }
 
+  get_keys_in_location(locationId: string): KeyItem[] {
+    return Array.from(this.items.values()).filter(
+      (i) => i.locationId === locationId,
+    );
+  }
+
   reset(): void {
     this.items.clear();
     this.seq = 0;

--- a/src/services/pathfinder.ts
+++ b/src/services/pathfinder.ts
@@ -1,0 +1,82 @@
+import { Door, ID } from '../core/types';
+import { keyItemService } from './key-items';
+
+export interface PathEdge {
+  to: ID;
+  door?: Door;
+}
+
+export type PathGraph = Record<ID, PathEdge[]>;
+
+function isLocked(door?: Door): boolean {
+  return door?.status === 'locked';
+}
+
+export function isPathPossible(graph: PathGraph, start: ID, goal: ID): boolean {
+  const visited = new Set<ID>();
+  const queue: ID[] = [start];
+  while (queue.length) {
+    const room = queue.shift()!;
+    if (room === goal) return true;
+    if (visited.has(room)) continue;
+    visited.add(room);
+    for (const edge of graph[room] ?? []) {
+      if (isLocked(edge.door)) continue;
+      queue.push(edge.to);
+    }
+  }
+  return false;
+}
+
+export function isPathPossibleWithLockpicking(
+  graph: PathGraph,
+  start: ID,
+  goal: ID,
+): boolean {
+  const visited = new Set<ID>();
+  const queue: ID[] = [start];
+  while (queue.length) {
+    const room = queue.shift()!;
+    if (room === goal) return true;
+    if (visited.has(room)) continue;
+    visited.add(room);
+    for (const edge of graph[room] ?? []) {
+      queue.push(edge.to);
+    }
+  }
+  return false;
+}
+
+export function isPathPossibleWithBacktracking(
+  graph: PathGraph,
+  start: ID,
+  goal: ID,
+): boolean {
+  type State = { room: ID; keys: Set<ID> };
+  const queue: State[] = [{ room: start, keys: new Set() }];
+  const seen = new Set<string>();
+
+  while (queue.length) {
+    const { room, keys } = queue.shift()!;
+    const keyString = Array.from(keys).sort().join(',');
+    const stateKey = `${room}|${keyString}`;
+    if (seen.has(stateKey)) continue;
+    seen.add(stateKey);
+
+    if (room === goal) return true;
+
+    const newKeys = new Set(keys);
+    for (const item of keyItemService.get_keys_in_location(room)) {
+      newKeys.add(item.doorId);
+    }
+
+    for (const edge of graph[room] ?? []) {
+      if (isLocked(edge.door) && !newKeys.has(edge.door!.id)) continue;
+      queue.push({ room: edge.to, keys: new Set(newKeys) });
+    }
+  }
+
+  return false;
+}
+
+export type { PathGraph as Graph, PathEdge as Edge };

--- a/tests/pathfinder.test.ts
+++ b/tests/pathfinder.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isPathPossible,
+  isPathPossibleWithLockpicking,
+  isPathPossibleWithBacktracking,
+  type Graph,
+} from '../src/services/pathfinder.js';
+import {
+  keyItemService,
+  PlacementRule,
+  PlacementTarget,
+} from '../src/services/key-items.js';
+import type { Door } from '../src/core/types.js';
+
+describe('pathfinder', () => {
+  beforeEach(() => {
+    keyItemService.reset();
+  });
+
+  it('evaluates paths considering locks, lockpicking, and key backtracking', () => {
+    const door: Door = { id: 'door1', type: 'normal', status: 'locked' };
+    const graph: Graph = {
+      A: [
+        { to: 'B', door },
+        { to: 'C' },
+      ],
+      B: [{ to: 'A', door }],
+      C: [{ to: 'A' }],
+    };
+
+    const key = keyItemService.generate_key(
+      'door1',
+      PlacementRule.REQUIRED,
+      PlacementTarget.ROOM_FEATURE,
+    );
+    keyItemService.mark_as_placed(key.id, 'C');
+
+    expect(isPathPossible(graph, 'A', 'B')).toBe(false);
+    expect(isPathPossibleWithLockpicking(graph, 'A', 'B')).toBe(true);
+    expect(isPathPossibleWithBacktracking(graph, 'A', 'B')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add pathfinder service to evaluate dungeon routes with lockpicks or key backtracking
- extend key item service to query keys by location
- test pathfinder scenarios involving locked doors and keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b6a7c2edc832fa83d5780b9eabe21