### PR TITLE
Add lock service and document pathfinding integration

### DIFF
--- a/FUTURE_PLANNING.md
+++ b/FUTURE_PLANNING.md
@@ -12,20 +12,21 @@ The `locks` service will centralize logic for evaluating door locks within a dun
 * **Outputs:**
   * `boolean` – `true` if the `door.id` matches `key.doorId`.
 
-### `checkDoorLock(dungeon, doorId)`
+### `checkDoorLock(dungeon, doorId, doors?)`
 * **Purpose:** report whether a door is locked and which key unlocks it.
 * **Inputs:**
-  * `dungeon: Dungeon` – the dungeon to inspect. May optionally contain `doors?: Door[]`.
-  * `doorId: string` – identifier of the door.
+  * `dungeon: Dungeon` – the dungeon to inspect for key items.
+  * `doorId: ID` – identifier of the door.
+  * `doors?: Door[]` – optional collection of doors available in the dungeon.
 * **Outputs:**
-  * `{ doorId: string; locked: boolean; requiredKey?: KeyItem }` – lock status and any matching key.
+  * `{ doorId: ID; locked: boolean; requiredKey?: KeyItem }` – lock status and any matching key.
 
 ## 3. locks.ts Implementation
 ```ts
-import { Dungeon, Door, KeyItem } from '../core/types';
+import { Dungeon, Door, ID, KeyItem } from '../core/types';
 
 export interface LockCheckResult {
-  doorId: string;
+  doorId: ID;
   locked: boolean;
   requiredKey?: KeyItem;
 }
@@ -35,14 +36,12 @@ export function canKeyOpenDoor(door: Door, key: KeyItem): boolean {
 }
 
 export function checkDoorLock(
-  dungeon: Dungeon & { doors?: Door[] },
-  doorId: string,
+  dungeon: Dungeon,
+  doorId: ID,
+  doors: Door[] = [],
 ): LockCheckResult {
-  const door = dungeon.doors?.find((d) => d.id === doorId);
-  if (!door) {
-    return { doorId, locked: false };
-  }
-  if (door.status !== 'locked') {
+  const door = doors.find((d) => d.id === doorId);
+  if (!door || door.status !== 'locked') {
     return { doorId, locked: false };
   }
   const requiredKey = dungeon.keyItems?.find((k) => canKeyOpenDoor(door, k));
@@ -50,7 +49,19 @@ export function checkDoorLock(
 }
 ```
 
-## 4. Example Usage in a System Module
+## 4. Integration with `corridors` and `pathfinder`
+The core `Dungeon` type lacks a canonical list of doors. Corridors and the
+`pathfinder` service currently track door information through their own data
+structures (e.g., `PathGraph` edges). The `locks` service therefore accepts an
+explicit list of `Door` objects rather than assuming a `dungeon.doors` field.
+
+* **`corridors.ts`:** corridor generation can attach `Door` instances to the
+  connections it creates and expose them as a door list for the lock service.
+* **`pathfinder.ts`:** pathfinding algorithms may consult `checkDoorLock` to
+  determine if an edge's door is traversable or requires a key, keeping lock
+  evaluation in one place.
+
+## 5. Example Usage in a System Module
 ```ts
 import { checkDoorLock } from '../services/locks';
 
@@ -58,7 +69,8 @@ export const dfrpg: SystemModule = {
   id: 'dfrpg',
   label: 'Dungeon Fantasy RPG',
   enrich(dungeon) {
-    const lockInfo = checkDoorLock(dungeon, 'door-1');
+    const dungeonDoors = [];
+    const lockInfo = checkDoorLock(dungeon, 'door-1', dungeonDoors);
     if (lockInfo.locked && lockInfo.requiredKey) {
       // annotate the dungeon or add narrative about the locked door
     }
@@ -67,7 +79,7 @@ export const dfrpg: SystemModule = {
 };
 ```
 
-## 5. Future Improvements
+## 6. Future Improvements
 * Support varying lock qualities (easy, average, superior) affecting difficulty or alternate solutions.
 * Introduce key types (master keys, skeleton keys) beyond simple `doorId` matching.
 * Allow multiple keys for a single door or multi-lock mechanisms.

--- a/src/services/locks.ts
+++ b/src/services/locks.ts
@@ -1,24 +1,32 @@
-import { Dungeon, Door, KeyItem } from '../core/types';
+import { Dungeon, Door, ID, KeyItem } from '../core/types';
 
 export interface LockCheckResult {
-  doorId: string;
+  doorId: ID;
   locked: boolean;
   requiredKey?: KeyItem;
 }
 
+/**
+ * Return `true` when the key is meant for the given door.
+ */
 export function canKeyOpenDoor(door: Door, key: KeyItem): boolean {
   return key.doorId === door.id;
 }
 
+/**
+ * Report whether a door is locked and which key unlocks it.
+ *
+ * The core {@link Dungeon} type does not currently track doors directly, so
+ * callers supply any door collection (e.g., from the corridor builder or a
+ * `PathGraph` edge list).
+ */
 export function checkDoorLock(
-  dungeon: Dungeon & { doors?: Door[] },
-  doorId: string,
+  dungeon: Dungeon,
+  doorId: ID,
+  doors: Door[] = [],
 ): LockCheckResult {
-  const door = dungeon.doors?.find((d) => d.id === doorId);
-  if (!door) {
-    return { doorId, locked: false };
-  }
-  if (door.status !== 'locked') {
+  const door = doors.find((d) => d.id === doorId);
+  if (!door || door.status !== 'locked') {
     return { doorId, locked: false };
   }
   const requiredKey = dungeon.keyItems?.find((k) => canKeyOpenDoor(door, k));

--- a/tests/locks.test.ts
+++ b/tests/locks.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { canKeyOpenDoor, checkDoorLock } from '../src/services/locks';
+import {
+  Dungeon,
+  Door,
+  KeyItem,
+  PlacementRule,
+  PlacementTarget,
+} from '../src/core/types';
+
+const lockedDoor: Door = { id: 'door-1', type: 'normal', status: 'locked' };
+const unlockedDoor: Door = { id: 'door-2', type: 'arch', status: 'secret' };
+const key: KeyItem = {
+  id: 'key-1',
+  doorId: 'door-1',
+  name: 'Key',
+  type: 'basic',
+  placementRule: PlacementRule.REQUIRED,
+  placementTarget: PlacementTarget.ROOM_FEATURE,
+};
+
+const baseDungeon: Dungeon = {
+  seed: 's',
+  rooms: [],
+  corridors: [],
+  keyItems: [key],
+};
+
+describe('canKeyOpenDoor', () => {
+  it('matches key to door by id', () => {
+    expect(canKeyOpenDoor(lockedDoor, key)).toBe(true);
+    expect(canKeyOpenDoor(unlockedDoor, key)).toBe(false);
+  });
+});
+
+describe('checkDoorLock', () => {
+  it('returns matching key when door is locked', () => {
+    const result = checkDoorLock(baseDungeon, lockedDoor.id, [lockedDoor]);
+    expect(result.locked).toBe(true);
+    expect(result.requiredKey).toBe(key);
+  });
+
+  it('reports unlocked when door not locked or missing', () => {
+    const result1 = checkDoorLock(baseDungeon, unlockedDoor.id, [unlockedDoor]);
+    expect(result1.locked).toBe(false);
+    const result2 = checkDoorLock(baseDungeon, 'missing', [lockedDoor]);
+    expect(result2.locked).toBe(false);
+  });
+
+  it('omits requiredKey when no key is present', () => {
+    const dungeon: Dungeon = { ...baseDungeon, keyItems: [] };
+    const result = checkDoorLock(dungeon, lockedDoor.id, [lockedDoor]);
+    expect(result.locked).toBe(true);
+    expect(result.requiredKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Implement lock utilities to evaluate door state and required keys without modifying the base Dungeon type
- Document how corridors and pathfinding can supply door data to the lock service
- Cover lock behaviors with targeted unit tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b71503978832fb065624d9ae5a9ae