### PR TITLE
feat: add DFRPG lock service

### DIFF
--- a/src/services/lock-generator.ts
+++ b/src/services/lock-generator.ts
@@ -1,0 +1,33 @@
+export interface DoorMaterialStats {
+  dr: number;
+  hp: number;
+}
+
+export interface LockGeneratorService {
+  /**
+   * DX modifier for a lockpicking attempt. Positive numbers are easier,
+   * negative numbers are harder.
+   */
+  getLockPickingModifier(quality: string): number;
+
+  /**
+   * Time in seconds required to pick a lock of the given quality.
+   */
+  getLockPickingTime(quality: string): number;
+
+  /**
+   * Modifier to the Perception roll required to notice a secret door.
+   */
+  getSecretDoorPerception(difficulty: string): number;
+
+  /**
+   * Skill or attribute checks required to open the secret door once found.
+   */
+  getSecretDoorOpeningChecks(type: string): string[];
+
+  /**
+   * Lookup table of door materials with Damage Resistance (DR) and Hit Points
+   * (HP) used when forcing open or destroying doors.
+   */
+  doorMaterials: Record<string, DoorMaterialStats>;
+}

--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -75,3 +75,5 @@ export const dfrpg: SystemModule = {
 };
 
 export default dfrpg;
+
+export { dfrpgLockService } from "./locks";

--- a/src/systems/dfrpg/locks.ts
+++ b/src/systems/dfrpg/locks.ts
@@ -1,0 +1,56 @@
+import { DoorMaterialStats, LockGeneratorService } from '../../services/lock-generator';
+
+const LOCK_MODIFIERS: Record<string, number> = {
+  simple: 5,
+  average: 0,
+  good: -3,
+  fine: -5,
+  magical: -10,
+};
+
+const PICK_TIMES: Record<string, number> = {
+  simple: 10,
+  average: 30,
+  good: 60,
+  fine: 120,
+  magical: 300,
+};
+
+const SECRET_DOOR_PERCEPTION: Record<string, number> = {
+  obvious: 0,
+  hidden: -2,
+  concealed: -4,
+  camouflaged: -6,
+};
+
+const SECRET_DOOR_CHECKS: Record<string, string[]> = {
+  basic: ['Traps', 'ST'],
+  trapped: ['Traps', 'ST'],
+  heavy: ['ST'],
+  stuck: ['ST'],
+};
+
+const DOOR_MATERIALS: Record<string, DoorMaterialStats> = {
+  wood: { dr: 3, hp: 15 },
+  stone: { dr: 6, hp: 90 },
+  iron: { dr: 8, hp: 120 },
+  steel: { dr: 10, hp: 150 },
+};
+
+export const dfrpgLockService: LockGeneratorService = {
+  getLockPickingModifier(quality: string): number {
+    return LOCK_MODIFIERS[quality] ?? 0;
+  },
+  getLockPickingTime(quality: string): number {
+    return PICK_TIMES[quality] ?? 60;
+  },
+  getSecretDoorPerception(difficulty: string): number {
+    return SECRET_DOOR_PERCEPTION[difficulty] ?? 0;
+  },
+  getSecretDoorOpeningChecks(type: string): string[] {
+    return SECRET_DOOR_CHECKS[type] ?? [];
+  },
+  doorMaterials: DOOR_MATERIALS,
+};
+
+export default dfrpgLockService;

--- a/tests/dfrpg-locks.test.ts
+++ b/tests/dfrpg-locks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { dfrpgLockService } from '../src/systems/dfrpg/locks';
+
+describe('dfrpgLockService', () => {
+  it('provides lockpicking modifiers', () => {
+    expect(dfrpgLockService.getLockPickingModifier('good')).toBe(-3);
+  });
+
+  it('provides lockpicking times', () => {
+    expect(dfrpgLockService.getLockPickingTime('simple')).toBe(10);
+  });
+
+  it('provides secret door perception modifiers', () => {
+    expect(dfrpgLockService.getSecretDoorPerception('camouflaged')).toBe(-6);
+  });
+
+  it('lists checks required to open secret doors', () => {
+    expect(dfrpgLockService.getSecretDoorOpeningChecks('trapped')).toContain('Traps');
+  });
+
+  it('exposes door material statistics', () => {
+    expect(dfrpgLockService.doorMaterials['wood']).toEqual({ dr: 3, hp: 15 });
+  });
+});


### PR DESCRIPTION
## Summary
- add generic LockGeneratorService interface to describe lock and door stats
- implement DFRPG-specific lock service for lockpicking, secret doors, and door materials
- export the lock service from the DFRPG system module

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b83960bcc832fac37846b29dd9b44