### PR TITLE
feat: add trap generator service

### DIFF
--- a/src/services/trap-generator.ts
+++ b/src/services/trap-generator.ts
@@ -1,0 +1,47 @@
+import { id } from './random';
+
+export interface Trap {
+  id: string;
+  name: string;
+  type: string;
+  location: string;
+  systemStats: Record<string, unknown>;
+  placed?: { x: number; y: number } | null;
+}
+
+export interface TrapSystem {
+  getTrapStats(type: string, difficulty: string): { name: string; [key: string]: unknown };
+}
+
+export class TrapGeneratorService {
+  private traps: Trap[] = [];
+
+  constructor(private readonly system: TrapSystem) {}
+
+  generateTrap(type: string, difficulty: string, location: string): Trap {
+    const stats = this.system.getTrapStats(type, difficulty);
+    const trap: Trap = {
+      id: id('trap'),
+      name: stats.name ?? `${difficulty} ${type} trap`,
+      type,
+      location,
+      systemStats: stats,
+      placed: null,
+    };
+    this.traps.push(trap);
+    return trap;
+  }
+
+  getUnplacedTraps(): Trap[] {
+    return this.traps.filter((t) => !t.placed);
+  }
+
+  placeTrap(trapId: string, coordinates: { x: number; y: number }): Trap | null {
+    const trap = this.traps.find((t) => t.id === trapId);
+    if (!trap) return null;
+    trap.placed = coordinates;
+    return trap;
+  }
+}
+
+export default TrapGeneratorService;

--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -77,3 +77,4 @@ export const dfrpg: SystemModule = {
 export default dfrpg;
 
 export { dfrpgLockService } from "./locks";
+export { dfrpgTrapService } from "./traps";

--- a/src/systems/dfrpg/traps.ts
+++ b/src/systems/dfrpg/traps.ts
@@ -1,0 +1,24 @@
+import { TrapSystem } from '../../services/trap-generator';
+
+const TRAPS: Record<string, Record<string, { name: string; [key: string]: unknown }>> = {
+  projectile: {
+    easy: { name: 'Simple Dart Trap', damage: '1d6 imp', trigger: 'pressure plate' },
+    hard: { name: 'Poisoned Dart Trap', damage: '1d6 imp', trigger: 'pressure plate', poison: 'HT-3' },
+  },
+  pit: {
+    easy: { name: 'Shallow Pit', damage: '2d crushing', depth: 10 },
+    hard: { name: 'Spiked Pit', damage: '3d impaling', depth: 20 },
+  },
+  magical: {
+    easy: { name: 'Alarm Rune', effect: 'alerts nearby foes' },
+    hard: { name: 'Fire Rune', damage: '2d burning', resistance: 'Dodge-2' },
+  },
+};
+
+export const dfrpgTrapService: TrapSystem = {
+  getTrapStats(type: string, difficulty: string) {
+    return TRAPS[type]?.[difficulty] ?? { name: `${difficulty} ${type} trap` };
+  },
+};
+
+export default dfrpgTrapService;

--- a/tests/traps.test.ts
+++ b/tests/traps.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import TrapGeneratorService, { TrapSystem } from '../src/services/trap-generator';
+import { dfrpgTrapService } from '../src/systems/dfrpg/traps';
+
+describe('TrapGeneratorService', () => {
+  it('generates traps with system stats and tracks placement', () => {
+    const svc = new TrapGeneratorService(dfrpgTrapService as TrapSystem);
+    const trap = svc.generateTrap('projectile', 'easy', 'corridor');
+    expect(trap.type).toBe('projectile');
+    expect(trap.location).toBe('corridor');
+    expect(trap.systemStats.damage).toBe('1d6 imp');
+
+    const unplaced = svc.getUnplacedTraps();
+    expect(unplaced).toHaveLength(1);
+
+    svc.placeTrap(trap.id, { x: 1, y: 2 });
+    expect(svc.getUnplacedTraps()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add TrapGeneratorService to manage trap creation and placement
- implement DFRPG trap stats provider
- test trap generation workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b86d583b4832f832d9b11f1410476