### PR TITLE
feat: add room labels to SVG maps

### DIFF
--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -63,11 +63,16 @@ export function renderSvg(d: Dungeon): string {
     }
   }
 
-  for (const r of d.rooms) {
+  d.rooms.forEach((r, i) => {
     parts.push(
       `<rect x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="white" stroke="black"/>`,
     );
-  }
+    const cx = (r.x + r.w / 2) * cell;
+    const cy = (r.y + r.h / 2) * cell;
+    parts.push(
+      `<text x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}">${i + 1}</text>`,
+    );
+  });
 
   parts.push("</svg>");
   return parts.join("");

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -8,5 +8,6 @@ describe("renderSvg", () => {
     const svg = renderSvg(d);
     expect(svg.startsWith("<svg")).toBe(true);
     expect(svg).toMatch(/<rect/);
+    expect(svg).toMatch(/<text[^>]*>1<\/text>/);
   });
 });


### PR DESCRIPTION
## Summary
- render room numbers as centered SVG text elements
- test that SVG output includes room labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8e8e6970832f8adc180d795f0015