### PR TITLE
Randomize corridor orientation using RNG

### DIFF
--- a/src/services/assembler.ts
+++ b/src/services/assembler.ts
@@ -8,6 +8,6 @@ export function buildDungeon(opts: { rooms?: number; seed?: string }) : Dungeon 
   const R = rng(seed);
   const n = Math.max(1, Math.floor(opts.rooms ?? 8));
   const rooms = generateRooms(n, 80, 60, R);
-  const corridors = connectRooms(rooms);
+  const corridors = connectRooms(rooms, R);
   return { seed, rooms, corridors, encounters: {} };
 }

--- a/src/services/corridors.ts
+++ b/src/services/corridors.ts
@@ -3,9 +3,9 @@ import { id } from './random';
 
 type Edge = { a: number; b: number; d: number };
 
-export function connectRooms(rooms: Room[]): Corridor[] {
+export function connectRooms(rooms: Room[], r: () => number): Corridor[] {
   if (rooms.length < 2) return [];
-  const centers = rooms.map(r => ({ x: r.x + Math.floor(r.w/2), y: r.y + Math.floor(r.h/2) }));
+  const centers = rooms.map(rm => ({ x: rm.x + Math.floor(rm.w/2), y: rm.y + Math.floor(rm.h/2) }));
   const edges: Edge[] = [];
   for (let i=0;i<rooms.length;i++) {
     for (let j=i+1;j<rooms.length;j++) {
@@ -26,19 +26,25 @@ export function connectRooms(rooms: Room[]): Corridor[] {
     if (find(e.a) !== find(e.b)) {
       unite(e.a, e.b);
       const from = rooms[e.a].id, to = rooms[e.b].id;
-      const path = manhattanPath(centers[e.a], centers[e.b]);
+      const path = manhattanPath(centers[e.a], centers[e.b], r);
       corridors.push({ id: id('cor'), from, to, path });
     }
   }
   return corridors;
 }
 
-function manhattanPath(a:{x:number;y:number}, b:{x:number;y:number}) {
-  const path = [];
+function manhattanPath(a:{x:number;y:number}, b:{x:number;y:number}, r: () => number) {
+  const path = [] as {x:number;y:number}[];
   const xStep = a.x < b.x ? 1 : -1;
-  for (let x=a.x; x!==b.x; x+=xStep) path.push({x, y:a.y});
   const yStep = a.y < b.y ? 1 : -1;
-  for (let y=a.y; y!==b.y; y+=yStep) path.push({x:b.x, y});
+  // Randomize whether to move horizontally or vertically first
+  if (r() < 0.5) {
+    for (let x=a.x; x!==b.x; x+=xStep) path.push({x, y:a.y});
+    for (let y=a.y; y!==b.y; y+=yStep) path.push({x:b.x, y});
+  } else {
+    for (let y=a.y; y!==b.y; y+=yStep) path.push({x:a.x, y});
+    for (let x=a.x; x!==b.x; x+=xStep) path.push({x, y:b.y});
+  }
   path.push({x:b.x, y:b.y});
   return path;
 }

--- a/tests/corridors.test.ts
+++ b/tests/corridors.test.ts
@@ -7,7 +7,7 @@ describe('corridors', () => {
   it('connectRooms returns a fully connected graph', () => {
     const r = rng('corridorTest');
     const rooms = generateRooms(15, 80, 60, r);
-    const corridors = connectRooms(rooms);
+    const corridors = connectRooms(rooms, r);
     expect(corridors.length).toBe(rooms.length - 1);
 
     // Each corridor should traverse at least one tile between rooms
@@ -34,5 +34,18 @@ describe('corridors', () => {
       }
     }
     expect(visited.size).toBe(rooms.length);
+  });
+
+  it('randomizes corridor orientation using the RNG', () => {
+    const rooms = [
+      { id: 'a', kind: 'chamber', x: 0, y: 0, w: 1, h: 1 },
+      { id: 'b', kind: 'chamber', x: 3, y: 4, w: 1, h: 1 },
+    ];
+
+    const horizFirst = connectRooms(rooms, () => 0)[0].path;
+    const vertFirst = connectRooms(rooms, () => 0.9)[0].path;
+
+    expect(horizFirst[1].y).toBe(horizFirst[0].y); // moved horizontally first
+    expect(vertFirst[1].x).toBe(vertFirst[0].x);   // moved vertically first
   });
 });


### PR DESCRIPTION
## Summary
- pass RNG to corridor generation and choose axis order randomly
- allow manhattanPath to traverse horizontally or vertically first
- update tests to cover corridor orientation randomness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9506beb4832fa52a93780290651c