### PR TITLE
Allow deterministic id generation

### DIFF
--- a/src/services/corridors.ts
+++ b/src/services/corridors.ts
@@ -27,7 +27,7 @@ export function connectRooms(rooms: Room[], r: () => number): Corridor[] {
       unite(e.a, e.b);
       const from = rooms[e.a].id, to = rooms[e.b].id;
       const path = manhattanPath(centers[e.a], centers[e.b], r);
-      corridors.push({ id: id('cor'), from, to, path });
+      corridors.push({ id: id('cor', r), from, to, path });
     }
   }
   return corridors;

--- a/src/services/doors.ts
+++ b/src/services/doors.ts
@@ -5,5 +5,5 @@ export const DOOR_TYPES: Door['type'][] = ['normal', 'arch', 'portcullis', 'hole
 export const DOOR_STATUSES: Door['status'][] = ['locked', 'trapped', 'barred', 'jammed', 'warded', 'secret'];
 
 export function generateDoor(r: () => number): Door {
-  return { id: id('door'), type: pick(r, DOOR_TYPES), status: pick(r, DOOR_STATUSES) };
+  return { id: id('door', r), type: pick(r, DOOR_TYPES), status: pick(r, DOOR_STATUSES) };
 }

--- a/src/services/random.ts
+++ b/src/services/random.ts
@@ -13,6 +13,6 @@ export function pick<T>(r: () => number, arr: T[]): T {
   return arr[Math.floor(r() * arr.length)];
 }
 
-export function id(prefix = 'id'): string {
-  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+export function id(prefix = 'id', r: () => number = Math.random): string {
+  return `${prefix}-${r().toString(36).slice(2, 10)}`;
 }

--- a/src/services/rooms.ts
+++ b/src/services/rooms.ts
@@ -17,7 +17,7 @@ export function generateRooms(n: number, width = 80, height = 60, r: () => numbe
     const x = 1 + Math.floor(r() * Math.max(1, width - w - 1));
     const y = 1 + Math.floor(r() * Math.max(1, height - h - 1));
     const kind = pick(r, KINDS);
-    const candidate: Room = { id: id('room'), kind, x, y, w, h };
+    const candidate: Room = { id: id('room', r), kind, x, y, w, h };
     if (!rooms.some(a => overlaps(a, candidate))) {
       rooms.push(candidate);
     }

--- a/src/services/trap-generator.ts
+++ b/src/services/trap-generator.ts
@@ -18,10 +18,10 @@ export class TrapGeneratorService {
 
   constructor(private readonly system: TrapSystem) {}
 
-  generateTrap(type: string, difficulty: string, location: string): Trap {
+  generateTrap(type: string, difficulty: string, location: string, r: () => number = Math.random): Trap {
     const stats = this.system.getTrapStats(type, difficulty);
     const trap: Trap = {
-      id: id('trap'),
+      id: id('trap', r),
       name: stats.name ?? `${difficulty} ${type} trap`,
       type,
       location,

--- a/tests/corridors.test.ts
+++ b/tests/corridors.test.ts
@@ -36,6 +36,16 @@ describe('corridors', () => {
     expect(visited.size).toBe(rooms.length);
   });
 
+  it('connectRooms generates consistent ids with same RNG', () => {
+    const r1 = rng('corridorIds');
+    const r2 = rng('corridorIds');
+    const rooms1 = generateRooms(10, 80, 60, r1);
+    const rooms2 = generateRooms(10, 80, 60, r2);
+    const corridors1 = connectRooms(rooms1, r1);
+    const corridors2 = connectRooms(rooms2, r2);
+    expect(corridors1.map((c) => c.id)).toEqual(corridors2.map((c) => c.id));
+  });
+
   it('randomizes corridor orientation using the RNG', () => {
     const rooms = [
       { id: 'a', kind: 'chamber', x: 0, y: 0, w: 1, h: 1 },

--- a/tests/doors.test.ts
+++ b/tests/doors.test.ts
@@ -15,4 +15,12 @@ describe('doors', () => {
     expect([...types].sort()).toEqual([...DOOR_TYPES].sort());
     expect([...statuses].sort()).toEqual([...DOOR_STATUSES].sort());
   });
+
+  it('generateDoor produces consistent ids with same RNG', () => {
+    const r1 = rng('doorIds');
+    const r2 = rng('doorIds');
+    const ids1 = Array.from({ length: 10 }, () => generateDoor(r1).id);
+    const ids2 = Array.from({ length: 10 }, () => generateDoor(r2).id);
+    expect(ids1).toEqual(ids2);
+  });
 });

--- a/tests/rooms.test.ts
+++ b/tests/rooms.test.ts
@@ -23,4 +23,12 @@ describe('rooms', () => {
       }
     }
   });
+
+  it('generateRooms produces consistent ids with same RNG', () => {
+    const r1 = rng('roomTest');
+    const r2 = rng('roomTest');
+    const rooms1 = generateRooms(10, 80, 60, r1);
+    const rooms2 = generateRooms(10, 80, 60, r2);
+    expect(rooms1.map((r) => r.id)).toEqual(rooms2.map((r) => r.id));
+  });
 });

--- a/tests/traps.test.ts
+++ b/tests/traps.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import TrapGeneratorService, { TrapSystem } from '../src/services/trap-generator';
 import { DFRPGTraps } from '../src/systems/dfrpg/DFRPGTraps';
+import { rng } from '../src/services/random.js';
 
 describe('TrapGeneratorService', () => {
   it('generates traps with system stats and tracks placement', () => {
     const svc = new TrapGeneratorService(DFRPGTraps as TrapSystem);
-    const trap = svc.generateTrap('pit', 'easy', 'corridor');
+    const r = rng('trapTest');
+    const trap = svc.generateTrap('pit', 'easy', 'corridor', r);
     expect(trap.type).toBe('pit');
     expect(trap.location).toBe('corridor');
     expect(trap.systemStats.effect.falling).toBe('1d6 per 10 ft');
@@ -15,5 +17,15 @@ describe('TrapGeneratorService', () => {
 
     svc.placeTrap(trap.id, { x: 1, y: 2 });
     expect(svc.getUnplacedTraps()).toHaveLength(0);
+  });
+
+  it('generates deterministic ids with same RNG', () => {
+    const svc1 = new TrapGeneratorService(DFRPGTraps as TrapSystem);
+    const svc2 = new TrapGeneratorService(DFRPGTraps as TrapSystem);
+    const r1 = rng('trapIds');
+    const r2 = rng('trapIds');
+    const t1 = svc1.generateTrap('pit', 'easy', 'corridor', r1);
+    const t2 = svc2.generateTrap('pit', 'easy', 'corridor', r2);
+    expect(t1.id).toBe(t2.id);
   });
 });


### PR DESCRIPTION
## Summary
- Allow `id` helper to accept an optional RNG for deterministic IDs
- Pass RNG through room, corridor, door, and trap generators
- Add tests verifying ID determinism for rooms, corridors, doors, and traps

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unexpected any in system-loader.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bbeffc748832f917f0c3cf6fe7081