### PR TITLE
Warn on invalid system names

### DIFF
--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -2,6 +2,7 @@ import { buildDungeon } from '@src/services/assembler';
 import { renderSvg } from '@src/services/render';
 import { exportFoundry } from '@src/services/foundry';
 import { loadSystemModule } from '@src/services/system-loader';
+import type { SystemModule } from '@src/core/types';
 
 async function generate(): Promise<void> {
   const roomsInput = document.getElementById('rooms') as HTMLInputElement;
@@ -19,7 +20,14 @@ async function generate(): Promise<void> {
   const opts = { rooms, seed };
   inputEl.textContent = JSON.stringify({ ...opts, system }, null, 2);
   const base = buildDungeon(opts);
-  const sys = await loadSystemModule(system, base.rng);
+  let sys: SystemModule;
+  try {
+    sys = await loadSystemModule(system, base.rng);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    alert(msg);
+    sys = await loadSystemModule('generic', base.rng);
+  }
   const enriched = await sys.enrich(base);
   const svg = renderSvg(enriched);
   mapEl.innerHTML = svg;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { buildDungeon } from "../services/assembler";
 import { loadSystemModule } from "../services/system-loader";
+import type { SystemModule } from "../core/types";
 import { renderAscii, renderSvg } from "../services/render";
 import { exportFoundry } from "../services/foundry";
 
@@ -22,7 +23,14 @@ program
   .option("--foundry", "output FoundryVTT-compatible JSON")
     .action(async (opts) => {
       const d = buildDungeon({ rooms: opts.rooms, seed: opts.seed, width: opts.width, height: opts.height });
-      const sys = await loadSystemModule(opts.system, d.rng);
+      let sys: SystemModule;
+      try {
+        sys = await loadSystemModule(opts.system, d.rng);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(msg);
+        sys = await loadSystemModule('generic', d.rng);
+      }
       const enriched = await sys.enrich(d, { sources: opts.source });
       if (opts.svg) {
         process.stdout.write(renderSvg(enriched) + "\n");

--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -2,6 +2,7 @@ import { buildDungeon } from "../services/assembler";
 import { renderSvg } from "../services/render";
 import { exportFoundry } from "../services/foundry";
 import { loadSystemModule } from "../services/system-loader";
+import type { SystemModule } from "../core/types";
 
 async function generate(): Promise<void> {
 const roomsInput = document.getElementById("rooms") as HTMLInputElement;
@@ -20,7 +21,14 @@ const system = systemInput.value || "generic";
   const opts = { rooms, seed };
   inputEl.textContent = JSON.stringify({ ...opts, system }, null, 2);
   const base = buildDungeon(opts);
-  const sys = await loadSystemModule(system, base.rng);
+  let sys: SystemModule;
+  try {
+    sys = await loadSystemModule(system, base.rng);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    alert(msg);
+    sys = await loadSystemModule('generic', base.rng);
+  }
   const enriched = await sys.enrich(base);
   mapEl.innerHTML = renderSvg(enriched);
   outputEl.textContent = JSON.stringify(enriched, null, 2);

--- a/src/services/system-loader.ts
+++ b/src/services/system-loader.ts
@@ -10,12 +10,12 @@ export async function loadSystemModule(name?: string, rng?: () => number): Promi
       return {
         ...base,
         enrich(d: Dungeon, opts?: Record<string, unknown>) {
-          return base.enrich(d, { ...(opts as any), rng });
+          const options = { ...(opts ?? {}), rng } as { sources?: string[]; rng?: () => number };
+          return base.enrich(d, options);
         }
       };
     }
     return mod.default;
   }
-  // fallback
-  return generic;
+  throw new Error(`Unknown system: ${name}`);
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,4 +15,13 @@ describe('cli', () => {
     expect(maxX).toBeLessThanOrEqual(30);
     expect(maxY).toBeLessThanOrEqual(20);
   });
+
+  it('falls back to generic system when unknown system specified', () => {
+    const result = spawnSync(process.execPath, ['--import', 'tsx', cliPath, 'generate', '--rooms', '1', '--system', 'bogus'], { encoding: 'utf-8' });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('Unknown system');
+    const d = JSON.parse(result.stdout) as Dungeon;
+    // generic system does not add encounters
+    expect(Object.keys(d.encounters || {}).length).toBe(0);
+  });
 });

--- a/tests/system-loader.test.ts
+++ b/tests/system-loader.test.ts
@@ -19,4 +19,8 @@ describe('system-loader', () => {
       expect(enc?.treasure).toBeDefined();
     });
   });
+
+  it('throws on invalid system name', async () => {
+    await expect(loadSystemModule('bogus')).rejects.toThrow('Unknown system');
+  });
 });


### PR DESCRIPTION
## Summary
- throw an error when an unknown system is requested
- surface system loader errors in CLI and GUI, falling back to generic
- test CLI fallback and system loader error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bcc5152b0832f9da78868ee5755bf