### PR TITLE
refactor: camelCase key item methods

### DIFF
--- a/src/services/key-items.ts
+++ b/src/services/key-items.ts
@@ -4,7 +4,7 @@ class KeyItemService {
   private items = new Map<string, KeyItem>();
   private seq = 0;
 
-  generate_key(
+  generateKey(
     doorId: string,
     placementRule: PlacementRule,
     placementTarget: PlacementTarget,
@@ -22,20 +22,20 @@ class KeyItemService {
     return item;
   }
 
-  get_unplaced_keys(): KeyItem[] {
+  getUnplacedKeys(): KeyItem[] {
     return Array.from(this.items.values()).filter(
       (i) => !i.locationId && i.placementRule !== PlacementRule.LOST,
     );
   }
 
-  mark_as_placed(keyId: string, locationId: string): void {
+  markAsPlaced(keyId: string, locationId: string): void {
     const item = this.items.get(keyId);
     if (item) {
       item.locationId = locationId;
     }
   }
 
-  get_keys_in_location(locationId: string): KeyItem[] {
+  getKeysInLocation(locationId: string): KeyItem[] {
     return Array.from(this.items.values()).filter(
       (i) => i.locationId === locationId,
     );

--- a/src/services/pathfinder.ts
+++ b/src/services/pathfinder.ts
@@ -66,7 +66,7 @@ export function isPathPossibleWithBacktracking(
     if (room === goal) return true;
 
     const newKeys = new Set(keys);
-    for (const item of keyItemService.get_keys_in_location(room)) {
+    for (const item of keyItemService.getKeysInLocation(room)) {
       newKeys.add(item.doorId);
     }
 

--- a/tests/key-items.test.ts
+++ b/tests/key-items.test.ts
@@ -11,30 +11,30 @@ describe('key item service', () => {
   });
 
   it('generates and lists unplaced keys', () => {
-    const key = keyItemService.generate_key(
+    const key = keyItemService.generateKey(
       'door1',
       PlacementRule.REQUIRED,
       PlacementTarget.MONSTER_LOOT,
     );
-    expect(keyItemService.get_unplaced_keys()).toEqual([key]);
+    expect(keyItemService.getUnplacedKeys()).toEqual([key]);
   });
 
   it('marks keys as placed', () => {
-    const key = keyItemService.generate_key(
+    const key = keyItemService.generateKey(
       'door2',
       PlacementRule.REQUIRED,
       PlacementTarget.TREASURE_CHEST,
     );
-    keyItemService.mark_as_placed(key.id, 'chest1');
-    expect(keyItemService.get_unplaced_keys()).toHaveLength(0);
+    keyItemService.markAsPlaced(key.id, 'chest1');
+    expect(keyItemService.getUnplacedKeys()).toHaveLength(0);
   });
 
   it('ignores lost keys when listing unplaced', () => {
-    keyItemService.generate_key(
+    keyItemService.generateKey(
       'door3',
       PlacementRule.LOST,
       PlacementTarget.MONSTER_LOOT,
     );
-    expect(keyItemService.get_unplaced_keys()).toHaveLength(0);
+    expect(keyItemService.getUnplacedKeys()).toHaveLength(0);
   });
 });

--- a/tests/pathfinder.test.ts
+++ b/tests/pathfinder.test.ts
@@ -28,12 +28,12 @@ describe('pathfinder', () => {
       C: [{ to: 'A' }],
     };
 
-    const key = keyItemService.generate_key(
+    const key = keyItemService.generateKey(
       'door1',
       PlacementRule.REQUIRED,
       PlacementTarget.ROOM_FEATURE,
     );
-    keyItemService.mark_as_placed(key.id, 'C');
+    keyItemService.markAsPlaced(key.id, 'C');
 
     expect(isPathPossible(graph, 'A', 'B')).toBe(false);
     expect(isPathPossibleWithLockpicking(graph, 'A', 'B')).toBe(true);


### PR DESCRIPTION
## Summary
- rename key item service methods to camelCase
- adjust pathfinder and tests for new method names

## Testing
- `npm test`
- `npm run build` (fails: src/systems/dfrpg/DFRPGTraps.ts(70,3): error TS2322)


------
https://chatgpt.com/codex/tasks/task_e_689bce329818832face136cd6061d34c