### PR TITLE
fix: include index signature in trap stats

### DIFF
--- a/src/systems/dfrpg/DFRPGTraps.ts
+++ b/src/systems/dfrpg/DFRPGTraps.ts
@@ -1,6 +1,6 @@
 import { TrapSystem } from '../../services/trap-generator';
 
-interface TrapStatBlock {
+interface TrapStatBlock extends Record<string, unknown> {
   name: string;
   detect: { skill: string; modifier?: number };
   disarm: { skill: string; modifier?: number };


### PR DESCRIPTION
## Summary
- ensure DFRPG trap stats implement index signature expected by `TrapSystem`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd04412cc832fb42b7f15e6c62104