### PR TITLE
Add tests for random utilities and foundry export scaling

### DIFF
--- a/tests/foundry-export.test.ts
+++ b/tests/foundry-export.test.ts
@@ -11,4 +11,13 @@ describe("exportFoundry", () => {
     expect(scene.width).toBeGreaterThan(0);
     expect(scene.height).toBeGreaterThan(0);
   });
+
+  it("scales walls and scene size based on grid", () => {
+    const d = buildDungeon({ rooms: 1, seed: "foundry" });
+    const scene100 = exportFoundry(d, 100);
+    const scene50 = exportFoundry(d, 50);
+    expect(scene50.width).toBe(scene100.width / 2);
+    expect(scene50.height).toBe(scene100.height / 2);
+    expect(scene50.walls[0].c).toEqual(scene100.walls[0].c.map((n) => n / 2));
+  });
 });

--- a/tests/random.test.ts
+++ b/tests/random.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { rng, pick, id } from '../src/services/random.js';
+
+describe('random utilities', () => {
+  it('rng generates deterministic sequences for the same seed', () => {
+    const r1 = rng('seed');
+    const r2 = rng('seed');
+    const seq1 = [r1(), r1(), r1()];
+    const seq2 = [r2(), r2(), r2()];
+    expect(seq1).toEqual(seq2);
+  });
+
+  it('pick selects an element based on RNG output', () => {
+    const arr = ['a', 'b', 'c', 'd', 'e'];
+    const r = () => 0.9; // should pick last element
+    expect(pick(r, arr)).toBe('e');
+  });
+
+  it('id uses the prefix and RNG output', () => {
+    const r = () => 0.123456;
+    expect(id('test', r)).toBe('test-4fzyo82m');
+  });
+});


### PR DESCRIPTION
## Summary
- test deterministic RNG, pick helper, and ID generator
- ensure foundry scene scaling honors grid size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd190c230832f9bb6bae2c7787841