### PR TITLE
feat: add themable corridor rendering

### DIFF
--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -1,5 +1,34 @@
 import { Dungeon } from "../core/types";
 
+export interface RenderTheme {
+  /** Color of the SVG background */
+  background: string;
+  /** Fill color for corridor tiles */
+  corridorFill: string;
+  /** Fill color for room rectangles */
+  roomFill: string;
+  /** Stroke color for room rectangles */
+  roomStroke: string;
+  /** Color for room numbering text */
+  textFill: string;
+}
+
+export const lightTheme: RenderTheme = {
+  background: "#ffffff",
+  corridorFill: "#cccccc",
+  roomFill: "#ffffff",
+  roomStroke: "#000000",
+  textFill: "#000000",
+};
+
+export const darkTheme: RenderTheme = {
+  background: "#000000",
+  corridorFill: "#555555",
+  roomFill: "#222222",
+  roomStroke: "#ffffff",
+  textFill: "#ffffff",
+};
+
 /**
  * Render a simple ASCII map of the dungeon. Rooms are drawn with '#' borders
  * and '.' interiors; corridor tiles are marked with '+'. Doors are currently
@@ -40,7 +69,7 @@ export function renderAscii(d: Dungeon): string {
  * currently visualized. The output is a standalone SVG string sized to the
  * dungeon's extents.
  */
-export function renderSvg(d: Dungeon): string {
+export function renderSvg(d: Dungeon, theme: RenderTheme = lightTheme): string {
   const cell = 20; // pixel size of a single grid square
   const points: { x: number; y: number }[] = [];
   for (const r of d.rooms) {
@@ -55,24 +84,25 @@ export function renderSvg(d: Dungeon): string {
   const height = maxY * cell;
   const parts: string[] = [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    `<rect x="0" y="0" width="${width}" height="${height}" fill="${theme.background}"/>`,
   ];
 
   for (const c of d.corridors) {
     for (const p of c.path) {
       parts.push(
-        `<rect x="${p.x * cell}" y="${p.y * cell}" width="${cell}" height="${cell}" fill="white" stroke="none"/>`,
+        `<rect x="${p.x * cell}" y="${p.y * cell}" width="${cell}" height="${cell}" fill="${theme.corridorFill}" stroke="none"/>`,
       );
     }
   }
 
   d.rooms.forEach((r, i) => {
     parts.push(
-      `<rect x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="white" stroke="black"/>`,
+      `<rect x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="${theme.roomFill}" stroke="${theme.roomStroke}"/>`,
     );
     const cx = (r.x + r.w / 2) * cell;
     const cy = (r.y + r.h / 2) * cell;
     parts.push(
-      `<text x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}">${i + 1}</text>`,
+      `<text x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}" fill="${theme.textFill}">${i + 1}</text>`,
     );
   });
 

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildDungeon } from "../src/services/assembler.js";
-import { renderSvg } from "../src/services/render.js";
+import { renderSvg, darkTheme } from "../src/services/render.js";
 
 describe("renderSvg", () => {
   it("produces svg markup", () => {
@@ -9,6 +9,14 @@ describe("renderSvg", () => {
     const svg = renderSvg(d);
     expect(svg.startsWith("<svg")).toBe(true);
     expect(svg).toMatch(/<rect/);
+    expect(svg).toMatch(/fill="#cccccc"/); // corridor color from light theme
     expect(svg).toMatch(/<text[^>]*>1<\/text>/);
+  });
+
+  it("applies theme colors", () => {
+    const d = buildDungeon({ rooms: 2, seed: "svgTheme" });
+    const svg = renderSvg(d, darkTheme);
+    expect(svg).toMatch(/fill="#555555"/); // corridor color from dark theme
+    expect(svg).toMatch(/fill="#222222"/); // room fill from dark theme
   });
 });


### PR DESCRIPTION
## Summary
- add light and dark SVG rendering themes
- render corridors with theme-defined colors to avoid white-on-white
- cover theming support in render tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c0676a224832f9230058edabc3e04