### PR TITLE
feat: show room key details in GUI

### DIFF
--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -6,8 +6,8 @@
   <style>
     body { font-family: monospace; padding: 1rem; }
     label { margin-right: 0.5rem; }
-    pre { white-space: pre; border: 1px solid #ccc; padding: 0.5rem; margin-top: 1rem; }
     #map { border: 1px solid #ccc; padding: 0.5rem; margin-top: 1rem; display: inline-block; }
+    #room-key { margin-top: 1rem; }
   </style>
 </head>
 <body>
@@ -25,10 +25,8 @@
     <a id="download-foundry" download="dungeon.json" style="margin-left: 1rem">Download Foundry JSON</a>
   </div>
   <div id="map"></div>
-  <h2>Input</h2>
-  <pre id="inputs"></pre>
-  <h2>Output</h2>
-  <pre id="outputs"></pre>
+  <h2>Room Key</h2>
+  <div id="room-key"></div>
   <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/src/gui/main.ts
+++ b/src/gui/main.ts
@@ -2,6 +2,7 @@ import { buildDungeon } from "../services/assembler";
 import { renderSvg } from "../services/render";
 import { exportFoundry } from "../services/foundry";
 import { loadSystemModule } from "../services/system-loader";
+import { populateRooms, htmlRoomDetails } from "../services/room-key";
 import type { SystemModule } from "../core/types";
 
 async function generate(): Promise<void> {
@@ -25,14 +26,9 @@ async function generate(): Promise<void> {
     alert("Missing map element");
     return;
   }
-  const inputEl = document.getElementById("inputs");
-  if (!(inputEl instanceof HTMLElement)) {
-    alert("Missing inputs element");
-    return;
-  }
-  const outputEl = document.getElementById("outputs");
-  if (!(outputEl instanceof HTMLElement)) {
-    alert("Missing outputs element");
+  const keyEl = document.getElementById("room-key");
+  if (!(keyEl instanceof HTMLElement)) {
+    alert("Missing room key element");
     return;
   }
   const foundryLink = document.getElementById("download-foundry");
@@ -46,7 +42,6 @@ async function generate(): Promise<void> {
   const system = systemInput.value || "generic";
 
   const opts = { rooms, seed };
-  inputEl.textContent = JSON.stringify({ ...opts, system }, null, 2);
   const base = buildDungeon(opts);
   let sys: SystemModule;
   try {
@@ -58,7 +53,8 @@ async function generate(): Promise<void> {
   }
   const enriched = await sys.enrich(base);
   mapEl.innerHTML = renderSvg(enriched);
-  outputEl.textContent = JSON.stringify(enriched, null, 2);
+  const details = populateRooms(enriched, enriched.rng ?? Math.random);
+  keyEl.innerHTML = htmlRoomDetails(enriched, details);
   const foundry = exportFoundry(enriched);
   const blob = new Blob([JSON.stringify(foundry, null, 2)], { type: "application/json" });
   foundryLink.href = URL.createObjectURL(blob);

--- a/src/services/room-key.ts
+++ b/src/services/room-key.ts
@@ -1,0 +1,100 @@
+import { Dungeon, Monster, Treasure, ID } from '../core/types';
+
+interface Weighted<T> {
+  item: T;
+  weight: number;
+}
+
+function weightedPick<T>(r: () => number, table: Weighted<T>[]): T {
+  const total = table.reduce((sum, entry) => sum + entry.weight, 0);
+  let roll = r() * total;
+  for (const entry of table) {
+    roll -= entry.weight;
+    if (roll < 0) return entry.item;
+  }
+  return table[0].item;
+}
+
+const FEATURE_TABLE: Weighted<string>[] = [
+  { item: 'crumbling statue', weight: 2 },
+  { item: 'moldy furniture', weight: 3 },
+  { item: 'tapestry', weight: 2 },
+  { item: 'ominous altar', weight: 1 },
+  { item: 'empty', weight: 5 },
+];
+
+const MONSTER_TABLE: Weighted<Monster>[] = [
+  { item: { name: 'Goblin' }, weight: 4 },
+  { item: { name: 'Skeleton' }, weight: 3 },
+  { item: { name: 'Orc' }, weight: 2 },
+  { item: { name: 'Ogre' }, weight: 1 },
+];
+
+const TREASURE_TABLE: Weighted<Treasure>[] = [
+  { item: { kind: 'coins', valueHint: 'minor' }, weight: 5 },
+  { item: { kind: 'gems', valueHint: 'standard' }, weight: 3 },
+  { item: { kind: 'magic', valueHint: 'major' }, weight: 1 },
+];
+
+export interface RoomDetail {
+  features: string[];
+  monsters: Monster[];
+  treasure: Treasure[];
+}
+
+export function featureRoom(r: () => number): string[] {
+  const features: string[] = [];
+  if (r() < 0.7) {
+    features.push(weightedPick(r, FEATURE_TABLE));
+    if (r() < 0.3) features.push(weightedPick(r, FEATURE_TABLE));
+  }
+  return features;
+}
+
+export function monsterRoom(r: () => number): Monster[] {
+  const monsters: Monster[] = [];
+  if (r() < 0.5) {
+    monsters.push({ ...weightedPick(r, MONSTER_TABLE) });
+  }
+  return monsters;
+}
+
+export function treasureRoom(r: () => number, hasMonsters = false): Treasure[] {
+  const treasure: Treasure[] = [];
+  if (hasMonsters || r() < 0.4) {
+    treasure.push({ ...weightedPick(r, TREASURE_TABLE) });
+  }
+  return treasure;
+}
+
+export function populateRooms(d: Dungeon, r: () => number = Math.random): Record<ID, RoomDetail> {
+  const details: Record<ID, RoomDetail> = {};
+  for (const room of d.rooms) {
+    const monsters = d.encounters?.[room.id]?.monsters ?? monsterRoom(r);
+    const treasure = d.encounters?.[room.id]?.treasure ?? treasureRoom(r, monsters.length > 0);
+    const features = featureRoom(r);
+    details[room.id] = { features, monsters, treasure };
+  }
+  return details;
+}
+
+export function htmlRoomDetails(d: Dungeon, details: Record<ID, RoomDetail>): string {
+  return d.rooms
+    .map((room, index) => {
+      const det = details[room.id] ?? { features: [], monsters: [], treasure: [] };
+      const parts: string[] = [`<section class="room"><h3>Room ${index + 1} (${room.kind})</h3>`];
+      if (det.features.length) {
+        parts.push(`<p><strong>Features:</strong> ${det.features.join(', ')}</p>`);
+      }
+      if (det.monsters.length) {
+        parts.push(`<p><strong>Monsters:</strong> ${det.monsters.map(m => m.name).join(', ')}</p>`);
+      }
+      if (det.treasure.length) {
+        parts.push(`<p><strong>Treasure:</strong> ${det.treasure.map(t => t.kind + (t.valueHint ? ` (${t.valueHint})` : '')).join(', ')}</p>`);
+      }
+      parts.push('</section>');
+      return parts.join('\n');
+    })
+    .join('\n');
+}
+


### PR DESCRIPTION
## Summary
- add room-key service to populate rooms with features, monsters and treasure
- render HTML room key in GUI instead of raw JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0b8a96f4832f9f5be610cdc7266c