### PR TITLE
feat: clean up DFRPG module to use proper GURPS references

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -30,6 +30,11 @@ export interface Monster {
   subclass?: string;
   notes?: string;
   source?: string;
+  reference?: string;
+  threat_rating?: 'fodder' | 'worthy' | 'boss';
+  group_size?: string;
+  tactics?: string;
+  frequency?: 'very_rare' | 'rare' | 'uncommon' | 'common' | 'very_common';
 }
 
 export interface Trap {

--- a/src/data/schemas/dfrpg.ts
+++ b/src/data/schemas/dfrpg.ts
@@ -15,17 +15,16 @@ export const dfrpgSchema: ModuleSchema = {
         { name: 'SM', type: 'number', required: false, description: 'Size Modifier' },
         { name: 'Subclass', type: 'string', required: false, description: 'Monster subclass' },
         { name: 'Source1', type: 'string', required: false, description: 'Primary source book' },
-        { name: 'hit_points', type: 'number', required: false, description: 'Hit Points' },
-        { name: 'armor_class', type: 'number', required: false, description: 'Damage Resistance' },
-        { name: 'attack_bonus', type: 'string', required: false, description: 'Attack skill level' },
-        { name: 'damage_dice', type: 'string', required: false, description: 'Damage dice (e.g., 2d6+1)' },
-        { name: 'frequency', type: 'enum', required: false, description: 'Encounter frequency', enumValues: ['very_rare', 'rare', 'uncommon', 'common', 'very_common'] },
-        { name: 'special_ability', type: 'string', required: false, description: 'Special abilities or traits' }
+        { name: 'reference', type: 'string', required: false, description: 'Book reference (e.g., "DFRPG Monsters p.XX")' },
+        { name: 'threat_rating', type: 'enum', required: false, description: 'Combat threat level', enumValues: ['fodder', 'worthy', 'boss'] },
+        { name: 'group_size', type: 'string', required: false, description: 'Typical group size (e.g., "small group (2-3)", "pack (4-8)")' },
+        { name: 'tactics', type: 'string', required: false, description: 'Tactical behavior and special combat notes' },
+        { name: 'frequency', type: 'enum', required: false, description: 'Encounter frequency', enumValues: ['very_rare', 'rare', 'uncommon', 'common', 'very_common'] }
       ],
       examples: [
-        ['Goblin Warrior', 'Mundane', '-2', 'Goblinoid', 'DFRPG', '8', '2', '12', '1d6-1', 'common', 'Sneaky, pack tactics'],
-        ['Skeleton Guardian', 'Undead', '0', 'Animated', 'DFRPG', '12', '4', '14', '1d6+1', 'uncommon', 'Immune to mind control, DR vs piercing'],
-        ['Fire Elemental', 'Elemental', '1', 'Fire', 'DFRPG', '20', '0', '16', '2d6 burn', 'rare', 'Burning touch, immune to fire']
+        ['Goblin Warrior', 'Mundane', '-2', 'Goblinoid', 'DFRPG', 'DFRPG Monsters p.34', 'fodder', 'pack (4-8)', 'Uses hit-and-run tactics, retreats when outnumbered', 'common'],
+        ['Skeleton Guardian', 'Undead', '0', 'Animated', 'DFRPG', 'DFRPG Monsters p.67', 'worthy', 'small group (2-3)', 'Guards specific locations, immune to mind control', 'uncommon'],
+        ['Fire Elemental', 'Elemental', '1', 'Fire', 'DFRPG', 'DFRPG Monsters p.89', 'boss', 'solitary', 'Burning aura, immune to fire and heat attacks', 'rare']
       ]
     },
     traps: {
@@ -37,15 +36,15 @@ export const dfrpgSchema: ModuleSchema = {
         { name: 'level', type: 'number', required: false, description: 'Trap complexity level (1-10)' },
         { name: 'trigger', type: 'string', required: false, description: 'How the trap is triggered' },
         { name: 'effect', type: 'string', required: false, description: 'Trap effect and damage' },
-        { name: 'detection_difficulty', type: 'number', required: false, description: 'Perception roll difficulty' },
-        { name: 'disarm_difficulty', type: 'number', required: false, description: 'Traps skill roll difficulty' },
+        { name: 'detection_skill', type: 'string', required: false, description: 'Detection skill and modifier (e.g., "Per-2", "Vision-4")' },
+        { name: 'disarm_skill', type: 'string', required: false, description: 'Disarm skill and modifier (e.g., "Traps+1", "DX-3")' },
         { name: 'reset_time', type: 'string', required: false, description: 'Time to reset (if applicable)' },
         { name: 'notes', type: 'string', required: false, description: 'Additional mechanics and flavor' }
       ],
       examples: [
-        ['Poisoned Needle', '2', 'Opening container', '1d-3 injury + HT-2 vs poison', '14', '12', 'Manual', 'Hidden in lock mechanism'],
-        ['Crushing Walls', '6', 'Pressure plate', '3d crushing per second', '12', '16', 'Never', 'Walls close over 3 seconds'],
-        ['Magical Glyph', '4', 'Touch or dispel', '2d+2 burning', '16', '15', 'Instant', 'Requires Thaumatology to understand']
+        ['Poisoned Needle', '2', 'Opening container', '1d-3 injury + HT-2 vs poison', 'Per-2', 'Traps', 'Manual', 'Hidden in lock mechanism'],
+        ['Crushing Walls', '6', 'Pressure plate', '3d crushing per second', 'Per+0', 'Traps-4', 'Never', 'Walls close over 3 seconds'],
+        ['Magical Glyph', '4', 'Touch or dispel', '2d+2 burning', 'Detect Magic-0', 'Thaumatology-3', 'Instant', 'Requires Thaumatology to understand']
       ]
     },
     doors: {

--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -26,6 +26,25 @@ const TREASURE: Treasure[] = [
   { kind: 'art', valueHint: 'minor' }
 ];
 
+const ROOM_MODIFIERS = {
+  environmental: [
+    { tag: 'darkness', description: 'Dark (-5 to vision rolls)', weight: 3 },
+    { tag: 'dim_light', description: 'Dim lighting (-2 to vision rolls)', weight: 2 },
+    { tag: 'bad_footing', description: 'Slippery/rough floor (-2 to Move, attack, and defense)', weight: 2 },
+    { tag: 'cramped', description: 'Low ceiling/narrow space (no retreating, -2 to swinging weapons)', weight: 1 },
+    { tag: 'damp', description: 'Wet and moldy (+1 to disease resistance rolls needed)', weight: 2 },
+    { tag: 'cold', description: 'Freezing conditions (HT rolls vs cold)', weight: 1 },
+    { tag: 'hot', description: 'Sweltering heat (HT rolls vs heat)', weight: 1 }
+  ],
+  tactical: [
+    { tag: 'high_ground', description: 'Elevated position (+1 to attack from above)', weight: 1 },
+    { tag: 'cover', description: 'Pillars/debris provide cover (+2 to +4 defense)', weight: 2 },
+    { tag: 'choke_point', description: 'Narrow entrance (limits attackers to 1-2 at a time)', weight: 1 },
+    { tag: 'multiple_exits', description: 'Several escape routes available', weight: 2 },
+    { tag: 'echo_chamber', description: 'Sound carries (+3 to Hearing rolls, -2 to Stealth)', weight: 1 }
+  ]
+};
+
 export const dfrpg: SystemModule = {
   id: 'dfrpg',
   label: 'GURPS Dungeon Fantasy',
@@ -89,7 +108,44 @@ export const dfrpg: SystemModule = {
       encounters[r.id] = { monsters, traps, treasure };
     });
 
-    return { ...d, encounters };
+    // Add GURPS room modifiers
+    const modifiedRooms = d.rooms.map((room) => {
+      const newTags = [...(room.tags || [])];
+      
+      // 40% chance for environmental modifier
+      if (R() < 0.4) {
+        const envModifiers = ROOM_MODIFIERS.environmental;
+        const totalWeight = envModifiers.reduce((sum, mod) => sum + mod.weight, 0);
+        let random = R() * totalWeight;
+        
+        for (const modifier of envModifiers) {
+          random -= modifier.weight;
+          if (random <= 0) {
+            newTags.push(`gurps:${modifier.tag}`, `gurps:${modifier.description}`);
+            break;
+          }
+        }
+      }
+      
+      // 30% chance for tactical modifier  
+      if (R() < 0.3) {
+        const tacticalModifiers = ROOM_MODIFIERS.tactical;
+        const totalWeight = tacticalModifiers.reduce((sum, mod) => sum + mod.weight, 0);
+        let random = R() * totalWeight;
+        
+        for (const modifier of tacticalModifiers) {
+          random -= modifier.weight;
+          if (random <= 0) {
+            newTags.push(`gurps:${modifier.tag}`, `gurps:${modifier.description}`);
+            break;
+          }
+        }
+      }
+      
+      return newTags.length > (room.tags?.length || 0) ? { ...room, tags: newTags } : room;
+    });
+
+    return { ...d, rooms: modifiedRooms, encounters };
   }
 };
 


### PR DESCRIPTION
## Summary
- Remove D&D-style stat blocks (HP, AC, attack bonuses) from DFRPG schema
- Replace with proper GURPS reference system using book citations and threat ratings
- Update trap mechanics to use GURPS skill notation instead of numeric difficulties
- Add environmental and tactical room modifiers with GURPS mechanical effects

## Changes Made
- **Monster Schema**: Replaced specific stats with reference fields, threat ratings (fodder/worthy/boss), group descriptors, and tactical notes
- **Trap System**: Changed from numeric difficulties to GURPS notation (Per-2, Traps+1, etc.)
- **Room Modifiers**: Added environmental conditions (darkness, bad footing, cramped) and tactical elements (cover, choke points, high ground)
- **Core Types**: Enhanced Monster interface to support new DFRPG fields

## Test Plan
- [ ] Verify DFRPG module generates proper references instead of specific stats
- [ ] Test that room modifiers appear with correct GURPS notation
- [ ] Check that trap examples use skill-based difficulties
- [ ] Validate schema examples match new field structure

🤖 Generated with [Claude Code](https://claude.ai/code)