### PR TITLE
fix: resolve duplicate HTML IDs and TypeScript issues in GUI

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -187,11 +187,6 @@
       <!-- Custom data items will be populated here -->
     </div>
   </div>
-  <div id="map"></div>
-  <h2>Room Key</h2>
-  <div id="room-key"></div>
-  <h2>Input</h2>
-  <pre id="inputs"></pre>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/apps/gui/src/import-wizard.ts
+++ b/apps/gui/src/import-wizard.ts
@@ -368,10 +368,3 @@ export class ImportWizardComponent {
     element.innerHTML = '';
   }
 }
-
-// Make it available globally for the delete buttons
-declare global {
-  interface Window {
-    importWizard: ImportWizardComponent;
-  }
-}

--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -4,7 +4,6 @@ import { exportFoundry } from '@src/services/foundry';
 import { loadSystemModule } from '@src/services/system-loader';
 import { populateRooms, htmlRoomDetails } from '@src/services/room-key';
 import { ImportWizardComponent } from './import-wizard';
-main
 import type { SystemModule } from '@src/core/types';
 
 async function generate(): Promise<void> {
@@ -91,9 +90,3 @@ document.addEventListener('DOMContentLoaded', () => {
   // Generate initial dungeon
   generate().catch(console.error);
 });
-
-// Also run on module load for development
-initializeTabs();
-importWizard = new ImportWizardComponent();
-window.importWizard = importWizard;
-generate().catch(console.error);

--- a/apps/gui/src/types.d.ts
+++ b/apps/gui/src/types.d.ts
@@ -1,0 +1,9 @@
+import { ImportWizardComponent } from './import-wizard';
+
+declare global {
+  interface Window {
+    importWizard: ImportWizardComponent;
+  }
+}
+
+export {};


### PR DESCRIPTION
This PR fixes several critical issues in the GUI application that were preventing proper dungeon generation output display.

## Changes Made

1. **Fixed Duplicate HTML IDs**: Removed duplicate elements with IDs map, room-key, and inputs from apps/gui/index.html
2. **Fixed TypeScript Issues**: Removed stray 'main' text in apps/gui/src/main.ts
3. **Added Type Declarations**: Created apps/gui/src/types.d.ts for proper TypeScript support
4. **Cleaned Up Code**: Removed duplicate initialization code and global declarations

## Testing

The application now works correctly - dungeon generation displays properly in the Generator tab with SVG maps, room key details, and input parameters all appearing as expected.