### PR TITLE
Link doors to corridors

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,9 @@ export interface Door {
   id: ID;
   type: 'normal' | 'arch' | 'portcullis' | 'hole';
   status: 'locked' | 'trapped' | 'barred' | 'jammed' | 'warded' | 'secret';
+  fromRoom?: ID;
+  toRoom?: ID;
+  location?: { x: number; y: number };
 }
 
 export interface Monster {

--- a/src/services/assembler.ts
+++ b/src/services/assembler.ts
@@ -19,6 +19,13 @@ export function buildDungeon(opts: { rooms?: number; seed?: string; width?: numb
   );
   const rooms = generateRooms(n, width, height, R);
   const corridors = connectRooms(rooms, R);
-  const doors = corridors.flatMap(() => [generateDoor(R), generateDoor(R)]);
+  const doors = corridors.flatMap(c => [
+    generateDoor(R, { fromRoom: c.from, toRoom: c.to, location: c.path[0] }),
+    generateDoor(R, {
+      fromRoom: c.to,
+      toRoom: c.from,
+      location: c.path[c.path.length - 1],
+    }),
+  ]);
   return { seed, rooms, corridors, doors, encounters: {}, rng: R };
 }

--- a/src/services/doors.ts
+++ b/src/services/doors.ts
@@ -4,6 +4,14 @@ import { id, pick } from './random';
 export const DOOR_TYPES: Door['type'][] = ['normal', 'arch', 'portcullis', 'hole'];
 export const DOOR_STATUSES: Door['status'][] = ['locked', 'trapped', 'barred', 'jammed', 'warded', 'secret'];
 
-export function generateDoor(r: () => number): Door {
-  return { id: id('door', r), type: pick(r, DOOR_TYPES), status: pick(r, DOOR_STATUSES) };
+export function generateDoor(
+  r: () => number,
+  endpoints: { fromRoom?: string; toRoom?: string; location?: { x: number; y: number } } = {},
+): Door {
+  return {
+    id: id('door', r),
+    type: pick(r, DOOR_TYPES),
+    status: pick(r, DOOR_STATUSES),
+    ...endpoints,
+  };
 }

--- a/tests/doors.test.ts
+++ b/tests/doors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateDoor, DOOR_TYPES, DOOR_STATUSES } from '../src/services/doors.js';
 import { rng } from '../src/services/random.js';
+import { buildDungeon } from '../src/services/assembler.js';
 
 describe('doors', () => {
   it('generateDoor produces valid types and statuses', () => {
@@ -8,9 +9,12 @@ describe('doors', () => {
     const types = new Set<string>();
     const statuses = new Set<string>();
     for (let i = 0; i < 100; i++) {
-      const d = generateDoor(r);
+      const d = generateDoor(r, { fromRoom: 'A', toRoom: 'B', location: { x: i, y: i } });
       types.add(d.type);
       statuses.add(d.status);
+      expect(d.fromRoom).toBe('A');
+      expect(d.toRoom).toBe('B');
+      expect(d.location).toEqual({ x: i, y: i });
     }
     expect([...types].sort()).toEqual([...DOOR_TYPES].sort());
     expect([...statuses].sort()).toEqual([...DOOR_STATUSES].sort());
@@ -19,8 +23,20 @@ describe('doors', () => {
   it('generateDoor produces consistent ids with same RNG', () => {
     const r1 = rng('doorIds');
     const r2 = rng('doorIds');
-    const ids1 = Array.from({ length: 10 }, () => generateDoor(r1).id);
-    const ids2 = Array.from({ length: 10 }, () => generateDoor(r2).id);
+    const ids1 = Array.from({ length: 10 }, () => generateDoor(r1, { fromRoom: 'X' }).id);
+    const ids2 = Array.from({ length: 10 }, () => generateDoor(r2, { fromRoom: 'X' }).id);
     expect(ids1).toEqual(ids2);
+  });
+
+  it('buildDungeon places doors at corridor endpoints', () => {
+    const d = buildDungeon({ rooms: 2, seed: 'doorDungeon' });
+    expect(d.corridors.length).toBeGreaterThan(0);
+    const c = d.corridors[0];
+    const firstDoor = d.doors.find(dr => dr.fromRoom === c.from && dr.toRoom === c.to);
+    const secondDoor = d.doors.find(dr => dr.fromRoom === c.to && dr.toRoom === c.from);
+    expect(firstDoor).toBeDefined();
+    expect(secondDoor).toBeDefined();
+    expect(firstDoor!.location).toEqual(c.path[0]);
+    expect(secondDoor!.location).toEqual(c.path[c.path.length - 1]);
   });
 });


### PR DESCRIPTION
## Summary
- enrich Door types with room linkage and coordinates
- generate doors with endpoint data
- place doors at corridor endpoints and test connectivity

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a134eb499c832fbe853c0deb740866