### PR TITLE
feat: render and export doorways

### DIFF
--- a/src/services/foundry.ts
+++ b/src/services/foundry.ts
@@ -1,12 +1,17 @@
-import { Dungeon } from "../core/types";
+import { Dungeon, Room } from "../core/types";
 
 export interface FoundryWall {
+  c: [number, number, number, number];
+}
+
+export interface FoundryDoor {
   c: [number, number, number, number];
 }
 
 export interface FoundryScene {
   name: string;
   walls: FoundryWall[];
+  doors: FoundryDoor[];
   width: number;
   height: number;
   grid: number;
@@ -14,8 +19,9 @@ export interface FoundryScene {
 
 /**
  * Convert a dungeon into a simple FoundryVTT Scene JSON. Each room and
- * corridor tile becomes floor space with surrounding walls. Doors are not
- * currently exported. The scene uses a fixed grid size.
+ * corridor tile becomes floor space with surrounding walls. Door segments are
+ * exported separately so virtual tabletops can render openable passages. The
+ * scene uses a fixed grid size.
  */
 export function exportFoundry(d: Dungeon, grid = 100): FoundryScene {
   const cells: { x: number; y: number }[] = [];
@@ -49,6 +55,38 @@ export function exportFoundry(d: Dungeon, grid = 100): FoundryScene {
     addEdge(x, y + 1, x, y);
   }
 
+  const doorEdge = (room: Room, tile: { x: number; y: number }) => {
+    if (tile.x < room.x) return [room.x, tile.y, room.x, tile.y + 1] as const;
+    if (tile.x >= room.x + room.w)
+      return [room.x + room.w, tile.y, room.x + room.w, tile.y + 1] as const;
+    if (tile.y < room.y) return [tile.x, room.y, tile.x + 1, room.y] as const;
+    if (tile.y >= room.y + room.h)
+      return [tile.x, room.y + room.h, tile.x + 1, room.y + room.h] as const;
+    return null;
+  };
+
+  const doorSegments: [number, number, number, number][] = [];
+  for (const c of d.corridors) {
+    if (c.path.length > 0) {
+      const start = c.path[0];
+      const end = c.path[c.path.length - 1];
+      const fromRoom = d.rooms.find((r) => r.id === c.from);
+      const toRoom = d.rooms.find((r) => r.id === c.to);
+      if (fromRoom) {
+        const seg = doorEdge(fromRoom, start);
+        if (seg) doorSegments.push(seg);
+      }
+      if (toRoom) {
+        const seg = doorEdge(toRoom, end);
+        if (seg) doorSegments.push(seg);
+      }
+    }
+  }
+
+  const doors = doorSegments.map(([x1, y1, x2, y2]) => ({
+    c: [x1 * grid, y1 * grid, x2 * grid, y2 * grid],
+  }));
+
   const walls: FoundryWall[] = Array.from(edges).map((e) => {
     const [x1, y1, x2, y2] = e.split(",").map(Number);
     return { c: [x1 * grid, y1 * grid, x2 * grid, y2 * grid] };
@@ -57,6 +95,7 @@ export function exportFoundry(d: Dungeon, grid = 100): FoundryScene {
   return {
     name: "Generated Dungeon",
     walls,
+    doors,
     width: maxX * grid,
     height: maxY * grid,
     grid,

--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -1,4 +1,4 @@
-import { Dungeon } from "../core/types";
+import { Dungeon, Room } from "../core/types";
 
 export interface RenderTheme {
   /** Color of the SVG background */
@@ -31,9 +31,9 @@ export const darkTheme: RenderTheme = {
 
 /**
  * Render a simple ASCII map of the dungeon. Rooms are drawn with '#' borders
- * and '.' interiors; corridor tiles are marked with '+'. Doors are currently
- * not depicted but the dungeon's door list is accepted for completeness.
- * The map is tightly cropped to the extents of the dungeon geometry.
+ * and '.' interiors; corridor tiles are marked with '+'. Door locations are
+ * marked with 'D' on the corridor tile adjacent to the room. The map is
+ * tightly cropped to the extents of the dungeon geometry.
  */
 export function renderAscii(d: Dungeon): string {
   const points: { x: number; y: number }[] = [];
@@ -59,17 +59,43 @@ export function renderAscii(d: Dungeon): string {
     for (const p of c.path) {
       if (grid[p.y]?.[p.x] === " ") grid[p.y][p.x] = "+";
     }
+    if (c.path.length > 0) {
+      const start = c.path[0];
+      const end = c.path[c.path.length - 1];
+      grid[start.y][start.x] = "D";
+      grid[end.y][end.x] = "D";
+    }
   }
   return grid.map((row) => row.join("")).join("\n");
 }
 
 /**
  * Render a very simple SVG representation of the dungeon. Rooms are drawn as
- * stroked rectangles and corridor tiles are filled squares. Doors are not
- * currently visualized. The output is a standalone SVG string sized to the
- * dungeon's extents.
+ * stroked rectangles and corridor tiles are filled squares. Doorways are shown
+ * as short lines on corridor-room boundaries. The output is a standalone SVG
+ * string sized to the dungeon's extents.
  */
-export function renderSvg(d: Dungeon, theme: RenderTheme = lightTheme): string {
+function doorEdge(room: Room, tile: { x: number; y: number }) {
+  if (tile.x < room.x)
+    return { x1: room.x, y1: tile.y, x2: room.x, y2: tile.y + 1 };
+  if (tile.x >= room.x + room.w)
+    return { x1: room.x + room.w, y1: tile.y, x2: room.x + room.w, y2: tile.y + 1 };
+  if (tile.y < room.y)
+    return { x1: tile.x, y1: room.y, x2: tile.x + 1, y2: room.y };
+  if (tile.y >= room.y + room.h)
+    return {
+      x1: tile.x,
+      y1: room.y + room.h,
+      x2: tile.x + 1,
+      y2: room.y + room.h,
+    };
+  return null;
+}
+
+export function renderSvg(
+  d: Dungeon,
+  theme: RenderTheme = lightTheme,
+): string {
   const cell = 20; // pixel size of a single grid square
   const points: { x: number; y: number }[] = [];
   for (const r of d.rooms) {
@@ -92,6 +118,26 @@ export function renderSvg(d: Dungeon, theme: RenderTheme = lightTheme): string {
       parts.push(
         `<rect x="${p.x * cell}" y="${p.y * cell}" width="${cell}" height="${cell}" fill="${theme.corridorFill}" stroke="none"/>`,
       );
+    }
+    if (c.path.length > 0) {
+      const start = c.path[0];
+      const end = c.path[c.path.length - 1];
+      const fromRoom = d.rooms.find((r) => r.id === c.from);
+      const toRoom = d.rooms.find((r) => r.id === c.to);
+      if (fromRoom) {
+        const edge = doorEdge(fromRoom, start);
+        if (edge)
+          parts.push(
+            `<line x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
+          );
+      }
+      if (toRoom) {
+        const edge = doorEdge(toRoom, end);
+        if (edge)
+          parts.push(
+            `<line x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
+          );
+      }
     }
   }
 

--- a/tests/foundry-export.test.ts
+++ b/tests/foundry-export.test.ts
@@ -3,21 +3,23 @@ import { buildDungeon } from "../src/services/assembler.js";
 import { exportFoundry } from "../src/services/foundry.js";
 
 describe("exportFoundry", () => {
-  it("creates a scene with walls", () => {
-    const d = buildDungeon({ rooms: 1, seed: "foundry" });
+  it("creates a scene with walls and doors", () => {
+    const d = buildDungeon({ rooms: 2, seed: "foundry" });
     expect(d.doors.length).toBe(d.corridors.length * 2);
     const scene = exportFoundry(d);
     expect(scene.walls.length).toBeGreaterThan(0);
+    expect(scene.doors.length).toBeGreaterThan(0);
     expect(scene.width).toBeGreaterThan(0);
     expect(scene.height).toBeGreaterThan(0);
   });
 
-  it("scales walls and scene size based on grid", () => {
-    const d = buildDungeon({ rooms: 1, seed: "foundry" });
+  it("scales walls, doors, and scene size based on grid", () => {
+    const d = buildDungeon({ rooms: 2, seed: "foundry" });
     const scene100 = exportFoundry(d, 100);
     const scene50 = exportFoundry(d, 50);
     expect(scene50.width).toBe(scene100.width / 2);
     expect(scene50.height).toBe(scene100.height / 2);
     expect(scene50.walls[0].c).toEqual(scene100.walls[0].c.map((n) => n / 2));
+    expect(scene50.doors[0].c).toEqual(scene100.doors[0].c.map((n) => n / 2));
   });
 });

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { buildDungeon } from '../src/services/assembler.js';
-import { renderAscii } from '../src/services/render.js';
+import { renderAscii, renderSvg } from '../src/services/render.js';
 
 describe('renderAscii', () => {
-  it('draws rooms and corridors', () => {
+  it('draws rooms, corridors, and doors', () => {
     const d = buildDungeon({ rooms: 2, seed: 'test' });
     expect(d.doors.length).toBe(d.corridors.length * 2);
     const ascii = renderAscii(d);
     expect(ascii).toMatch(/#/); // room borders
     expect(ascii).toMatch(/[.+#]/); // some map characters
+    expect(ascii).toMatch(/D/); // door symbols
+  });
+});
+
+describe('renderSvg', () => {
+  it('includes door lines', () => {
+    const d = buildDungeon({ rooms: 2, seed: 'svgDoor' });
+    const svg = renderSvg(d);
+    expect(svg).toMatch(/<line/);
   });
 });


### PR DESCRIPTION
## Summary
- depict doors at corridor-room junctions in ASCII and SVG renderings
- export door segments in Foundry scenes for openable passages
- test door rendering and export logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a134e83e94832fa8f227447a0b7666