### PR TITLE
feat: support tag options in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,17 @@ pnpm doa generate --rooms=20 --svg > map.svg
 pnpm doa generate --rooms=15 --foundry > foundry.json
 pnpm doa generate --rooms=8 --ascii
 pnpm doa generate --rooms=5 --width=40 --height=30
+pnpm doa generate --rooms=5 --theme=generic-undead --monster-tag=undead --trap-tag=mechanical --treasure-tag=coins
 ```
 
 Use `--width` and `--height` to control the overall map dimensions.
+
+Tag options allow more control over generated content:
+
+* `--theme <id>` – apply a predefined theme to rooms and encounters
+* `--monster-tag <tag>` – require monsters to include the tag (repeatable)
+* `--trap-tag <tag>` – require traps to include the tag (repeatable)
+* `--treasure-tag <tag>` – require treasure to include the tag (repeatable)
 
 4. GUI:
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,25 @@ program
   .option("--seed <seed>", "random seed")
   .option("--system <name>", "system module to use (generic|dfrpg)", "generic")
   .option("--source <src...>", "sources to include (system-specific)")
+  .option("--theme <id>", "theme id to apply to rooms and encounters")
+  .option(
+    "--monster-tag <tag>",
+    "require monsters to include tag (repeatable)",
+    (v, p) => [...p, v],
+    [] as string[],
+  )
+  .option(
+    "--trap-tag <tag>",
+    "require traps to include tag (repeatable)",
+    (v, p) => [...p, v],
+    [] as string[],
+  )
+  .option(
+    "--treasure-tag <tag>",
+    "require treasure to include tag (repeatable)",
+    (v, p) => [...p, v],
+    [] as string[],
+  )
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
@@ -31,7 +50,16 @@ program
         console.error(msg);
         sys = await loadSystemModule('generic', d.rng);
       }
-      const enriched = await sys.enrich(d, { sources: opts.source });
+      const tagOptions =
+        opts.theme || opts.monsterTag.length || opts.trapTag.length || opts.treasureTag.length
+          ? {
+              theme: opts.theme,
+              monsters: opts.monsterTag.length ? { requiredTags: opts.monsterTag } : undefined,
+              traps: opts.trapTag.length ? { requiredTags: opts.trapTag } : undefined,
+              treasure: opts.treasureTag.length ? { requiredTags: opts.treasureTag } : undefined,
+            }
+          : undefined;
+      const enriched = await sys.enrich(d, { sources: opts.source, tags: tagOptions });
       if (opts.svg) {
         process.stdout.write(renderSvg(enriched) + "\n");
       } else if (opts.ascii) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -24,4 +24,38 @@ describe('cli', () => {
     // ensure dungeon structure is still returned
     expect(Array.isArray(d.rooms)).toBe(true);
   });
+
+  it('applies theme and tag filters', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        cliPath,
+        'generate',
+        '--rooms',
+        '1',
+        '--seed',
+        'seed1',
+        '--theme',
+        'generic-undead',
+        '--monster-tag',
+        'undead',
+        '--trap-tag',
+        'mechanical',
+        '--treasure-tag',
+        'coins',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(0);
+    const d = JSON.parse(result.stdout) as Dungeon;
+    const room = d.rooms[0];
+    expect(room.tags).toContain('undead');
+    const enc = d.encounters?.[room.id];
+    expect(enc?.monsters.every((m) => m.tags?.includes('undead'))).toBe(true);
+    expect(enc?.traps.every((t) => t.tags?.includes('mechanical'))).toBe(true);
+    expect(enc?.treasure.every((t) => t.tags?.includes('coins'))).toBe(true);
+  });
 });
+


### PR DESCRIPTION
## Summary
- add `--theme`, `--monster-tag`, `--trap-tag`, and `--treasure-tag` flags to CLI
- forward tag options to system enrich phase
- document tag flags and cover them with tests

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a134e3bcc8832fac1efa57f69b2a73