### PR TITLE
feat(cli): add layout type option

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,13 +16,23 @@ program
   .option("--width <n>", "map width", (v) => parseInt(v, 10))
   .option("--height <n>", "map height", (v) => parseInt(v, 10))
   .option("--seed <seed>", "random seed")
+  .option(
+    "--layout-type <type>",
+    "advanced layout type (rectangle, square, box, cross, etc.)"
+  )
   .option("--system <name>", "system module to use (generic|dfrpg)", "generic")
   .option("--source <src...>", "sources to include (system-specific)")
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
     .action(async (opts) => {
-      const d = buildDungeon({ rooms: opts.rooms, seed: opts.seed, width: opts.width, height: opts.height });
+      const d = buildDungeon({
+        rooms: opts.rooms,
+        seed: opts.seed,
+        width: opts.width,
+        height: opts.height,
+        layoutType: opts.layoutType,
+      });
       let sys: SystemModule;
       try {
         sys = await loadSystemModule(opts.system, d.rng);

--- a/src/services/assembler.ts
+++ b/src/services/assembler.ts
@@ -3,8 +3,54 @@ import { rng } from './random';
 import { generateRooms } from './rooms';
 import { connectRooms } from './corridors';
 import { generateDoor } from './doors';
+import { MapGenerator, type MapGenerationOptions } from './map-generator';
 
-export function buildDungeon(opts: { rooms?: number; seed?: string; width?: number; height?: number }): Dungeon {
+export interface BuildDungeonOptions {
+  rooms?: number;
+  seed?: string;
+  width?: number;
+  height?: number;
+  // Advanced map options (delegated to MapGenerator)
+  layoutType?: MapGenerationOptions['layoutType'];
+  roomLayout?: MapGenerationOptions['roomLayout'];
+  roomSize?: MapGenerationOptions['roomSize'];
+  roomShape?: MapGenerationOptions['roomShape'];
+  corridorType?: MapGenerationOptions['corridorType'];
+  allowDeadends?: boolean;
+  stairsUp?: boolean;
+  stairsDown?: boolean;
+  entranceFromPeriphery?: boolean;
+}
+
+export function buildDungeon(opts: BuildDungeonOptions): Dungeon {
+  // If a layout type or other advanced option is provided, delegate to MapGenerator
+  if (opts.layoutType || opts.roomLayout || opts.roomSize || opts.roomShape || opts.corridorType) {
+    const generator = new MapGenerator(opts.seed);
+    const options: MapGenerationOptions = {
+      rooms: Math.max(1, Math.floor(opts.rooms ?? 8)),
+      width: Math.max(
+        1,
+        Math.floor(typeof opts.width === 'number' && !Number.isNaN(opts.width) ? opts.width : 80),
+      ),
+      height: Math.max(
+        1,
+        Math.floor(typeof opts.height === 'number' && !Number.isNaN(opts.height) ? opts.height : 60),
+      ),
+      seed: opts.seed,
+      layoutType: opts.layoutType ?? 'rectangle',
+      roomLayout: opts.roomLayout ?? 'scattered',
+      roomSize: opts.roomSize ?? 'medium',
+      roomShape: opts.roomShape ?? 'rectangular',
+      corridorType: opts.corridorType ?? 'straight',
+      allowDeadends: opts.allowDeadends ?? true,
+      stairsUp: opts.stairsUp ?? false,
+      stairsDown: opts.stairsDown ?? false,
+      entranceFromPeriphery: opts.entranceFromPeriphery ?? false,
+    };
+    return generator.generateDungeon(options);
+  }
+
+  // Basic/default dungeon generation
   const seed = opts.seed ?? Math.random().toString(36).slice(2, 10);
   const R = rng(seed);
   const n = Math.max(1, Math.floor(opts.rooms ?? 8));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,6 +16,18 @@ describe('cli', () => {
     expect(maxY).toBeLessThanOrEqual(20);
   });
 
+  it('generates using advanced layout type when provided', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', cliPath, 'generate', '--rooms', '1', '--layout-type', 'square', '--seed', 'cli'],
+      { encoding: 'utf-8' }
+    );
+    expect(result.status).toBe(0);
+    const d = JSON.parse(result.stdout) as Dungeon;
+    expect(Array.isArray(d.rooms)).toBe(true);
+    expect(d.rooms.length).toBeGreaterThan(0);
+  });
+
   it('falls back to generic system when unknown system specified', () => {
     const result = spawnSync(process.execPath, ['--import', 'tsx', cliPath, 'generate', '--rooms', '1', '--system', 'bogus'], { encoding: 'utf-8' });
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- add `--layout-type` flag to CLI and pass through to assembler
- extend assembler to delegate advanced requests to MapGenerator
- test CLI with layout-type option

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a134e07ca4832fb4c63e1090aca6c7