### PR TITLE
Derive door endpoints from corridor data

### DIFF
--- a/src/services/map-generator.ts
+++ b/src/services/map-generator.ts
@@ -1,5 +1,6 @@
 import { Dungeon, Room, Corridor, Door } from '../core/types';
 import { rng } from './random';
+import { generateDoor } from './doors';
 
 export interface MapGenerationOptions {
   // Layout Types
@@ -705,29 +706,15 @@ export class MapGenerator {
    * Generate doors for corridors
    */
   private generateDoors(corridors: Corridor[]): Door[] {
-    const doors: Door[] = [];
-    
-    corridors.forEach((corridor, index) => {
-      // Add doors at corridor endpoints
-      if (corridor.path.length > 0) {
-        const start = corridor.path[0];
-        const end = corridor.path[corridor.path.length - 1];
-        
-        doors.push({
-          id: `door-${index}-start`,
-          type: 'normal',
-          status: this.R() < 0.3 ? 'locked' : 'secret'
-        });
-        
-        doors.push({
-          id: `door-${index}-end`,
-          type: 'normal',
-          status: this.R() < 0.3 ? 'locked' : 'secret'
-        });
-      }
+    return corridors.flatMap((corridor) => {
+      if (corridor.path.length === 0) return [];
+      const start = corridor.path[0];
+      const end = corridor.path[corridor.path.length - 1];
+      return [
+        generateDoor(this.R, { fromRoom: corridor.from, toRoom: corridor.to, location: start }),
+        generateDoor(this.R, { fromRoom: corridor.to, toRoom: corridor.from, location: end }),
+      ];
     });
-    
-    return doors;
   }
 }
 

--- a/tests/doors.test.ts
+++ b/tests/doors.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { generateDoor, DOOR_TYPES, DOOR_STATUSES } from '../src/services/doors.js';
 import { rng } from '../src/services/random.js';
 import { buildDungeon } from '../src/services/assembler.js';
+import { MapGenerator } from '../src/services/map-generator.js';
 
 describe('doors', () => {
   it('generateDoor produces valid types and statuses', () => {
@@ -38,5 +39,35 @@ describe('doors', () => {
     expect(secondDoor).toBeDefined();
     expect(firstDoor!.location).toEqual(c.path[0]);
     expect(secondDoor!.location).toEqual(c.path[c.path.length - 1]);
+    expect(DOOR_STATUSES).toContain(firstDoor!.status);
+    expect(DOOR_STATUSES).toContain(secondDoor!.status);
+  });
+
+  it('MapGenerator places doors at corridor endpoints', () => {
+    const generator = new MapGenerator('doorMap');
+    const d = generator.generateDungeon({
+      layoutType: 'rectangle',
+      roomLayout: 'scattered',
+      roomSize: 'medium',
+      roomShape: 'rectangular',
+      corridorType: 'straight',
+      allowDeadends: false,
+      stairsUp: false,
+      stairsDown: false,
+      entranceFromPeriphery: false,
+      rooms: 2,
+      width: 80,
+      height: 60,
+    });
+    expect(d.corridors.length).toBeGreaterThan(0);
+    const c = d.corridors[0];
+    const firstDoor = d.doors.find(dr => dr.fromRoom === c.from && dr.toRoom === c.to);
+    const secondDoor = d.doors.find(dr => dr.fromRoom === c.to && dr.toRoom === c.from);
+    expect(firstDoor).toBeDefined();
+    expect(secondDoor).toBeDefined();
+    expect(firstDoor!.location).toEqual(c.path[0]);
+    expect(secondDoor!.location).toEqual(c.path[c.path.length - 1]);
+    expect(DOOR_STATUSES).toContain(firstDoor!.status);
+    expect(DOOR_STATUSES).toContain(secondDoor!.status);
   });
 });


### PR DESCRIPTION
## Summary
- use corridor endpoints to generate doors with from/to room IDs and locations
- cover all door status enums when creating doors
- add tests validating door placement for buildDungeon and MapGenerator

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13beb6c1c832fad121fa90c74538c