### PR TITLE
Fix wandering monster generation and add test

### DIFF
--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -285,7 +285,11 @@ export const dfrpg: SystemModule = {
     });
 
     // Generate wandering monsters based on monsters placed in the dungeon
-    const wanderingMonsters = wanderingMonsterService.generateWanderingMonsters(d);
+    // Use the updated encounters rather than the original dungeon object
+    const wanderingMonsters = wanderingMonsterService.generateWanderingMonsters({
+      ...d,
+      encounters
+    });
     if (wanderingMonsters.length > 0) {
       console.log(`DFRPG: Generated ${wanderingMonsters.length} wandering monster entries`);
     }

--- a/tests/wandering-monsters.test.ts
+++ b/tests/wandering-monsters.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildDungeon } from '../src/services/assembler.js';
+import { dfrpg } from '../src/systems/dfrpg/index.js';
+
+describe('wandering monsters', () => {
+  it('generates a wandering monster table when encounters have monsters', () => {
+    const dungeon = buildDungeon({ rooms: 3, seed: 'wandering' });
+    const enriched = dfrpg.enrich(dungeon, { rng: () => 0 });
+
+    const totalMonsters = Object.values(enriched.encounters)
+      .flatMap(e => e.monsters)
+      .length;
+    expect(totalMonsters).toBeGreaterThan(0);
+    expect(enriched.wanderingMonsters?.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure wandering monsters use updated encounters during DFRPG enrichment
- add test verifying wandering monster table is produced

## Testing
- `pnpm lint`
- `pnpm test` *(fails: TypeError encounter is not iterable, expected 'csm43' to contain 'df16', expected 0 to be greater than 0, Cannot read properties of undefined (reading 'c'), expected 7 to be 6, expected '<svg xmlns="http://www.w3.org/2000/sv…' to match /<line/)*
- `pnpm test tests/wandering-monsters.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a162ad3358832fa5fa153de6f550f9