### PR TITLE
feat(cli): expose advanced map options

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,10 @@ import { renderAscii, renderSvg } from "../services/render";
 import { exportFoundry } from "../services/foundry";
 
 const program = new Command();
-program.name("doa").description("DungeonsOnAutomatic – modular dungeon generator").version("0.1.0");
+program
+  .name("doa")
+  .description("DungeonsOnAutomatic – modular dungeon generator")
+  .version("0.1.0");
 
 program
   .command("generate")
@@ -18,7 +21,27 @@ program
   .option("--seed <seed>", "random seed")
   .option(
     "--layout-type <type>",
-    "advanced layout type (rectangle, square, box, cross, etc.)"
+    "advanced layout type (rectangle, square, box, cross, etc.)",
+  )
+  .option(
+    "--room-layout <layout>",
+    "room layout (sparse|scattered|dense|symmetric)",
+  )
+  .option(
+    "--room-size <size>",
+    "room size (small|medium|large|mixed)",
+  )
+  .option(
+    "--room-shape <shape>",
+    "room shape (rectangular|round|hexagonal|mixed)",
+  )
+  .option(
+    "--corridor-type <type>",
+    "corridor type (maze|winding|straight|mixed)",
+  )
+  .option(
+    "--no-allow-deadends",
+    "disallow deadends when generating corridors",
   )
   .option("--stairs-up", "include stairs up to upper level")
   .option("--stairs-down", "include stairs down to lower level")
@@ -47,44 +70,50 @@ program
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
-    .action(async (opts) => {
-      const d = buildDungeon({
-        rooms: opts.rooms,
-        seed: opts.seed,
-        width: opts.width,
-        height: opts.height,
-        layoutType: opts.layoutType,
-        stairsUp: opts.stairsUp,
-        stairsDown: opts.stairsDown,
-        entranceFromPeriphery: opts.entranceFromPeriphery,
-      });
-      let sys: SystemModule;
-      try {
-        sys = await loadSystemModule(opts.system, d.rng);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(msg);
-        sys = await loadSystemModule('generic', d.rng);
-      }
-      const tagOptions =
-        opts.theme || opts.monsterTag.length || opts.trapTag.length || opts.treasureTag.length
-          ? {
-              theme: opts.theme,
-              monsters: opts.monsterTag.length ? { requiredTags: opts.monsterTag } : undefined,
-              traps: opts.trapTag.length ? { requiredTags: opts.trapTag } : undefined,
-              treasure: opts.treasureTag.length ? { requiredTags: opts.treasureTag } : undefined,
-            }
-          : undefined;
-      const enriched = await sys.enrich(d, { sources: opts.source, tags: tagOptions });
-      if (opts.svg) {
-        process.stdout.write(renderSvg(enriched) + "\n");
-      } else if (opts.ascii) {
-        process.stdout.write(renderAscii(enriched) + "\n");
-      } else if (opts.foundry) {
-        process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");
-      } else {
-        process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
-      }
+  .action(async (opts) => {
+    const d = buildDungeon({
+      rooms: opts.rooms,
+      seed: opts.seed,
+      width: opts.width,
+      height: opts.height,
+      layoutType: opts.layoutType,
+      roomLayout: opts.roomLayout,
+      roomSize: opts.roomSize,
+      roomShape: opts.roomShape,
+      corridorType: opts.corridorType,
+      allowDeadends: opts.allowDeadends,
+      stairsUp: opts.stairsUp,
+      stairsDown: opts.stairsDown,
+      entranceFromPeriphery: opts.entranceFromPeriphery,
     });
+    let sys: SystemModule;
+    try {
+      sys = await loadSystemModule(opts.system, d.rng);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(msg);
+      sys = await loadSystemModule("generic", d.rng);
+    }
+    const tagOptions =
+      opts.theme || opts.monsterTag.length || opts.trapTag.length || opts.treasureTag.length
+        ? {
+            theme: opts.theme,
+            monsters: opts.monsterTag.length ? { requiredTags: opts.monsterTag } : undefined,
+            traps: opts.trapTag.length ? { requiredTags: opts.trapTag } : undefined,
+            treasure: opts.treasureTag.length ? { requiredTags: opts.treasureTag } : undefined,
+          }
+        : undefined;
+    const enriched = await sys.enrich(d, { sources: opts.source, tags: tagOptions });
+    if (opts.svg) {
+      process.stdout.write(renderSvg(enriched) + "\n");
+    } else if (opts.ascii) {
+      process.stdout.write(renderAscii(enriched) + "\n");
+    } else if (opts.foundry) {
+      process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");
+    } else {
+      process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
+    }
+  });
 
 program.parseAsync(process.argv);
+

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -28,6 +28,35 @@ describe('cli', () => {
     expect(d.rooms.length).toBeGreaterThan(0);
   });
 
+  it('accepts advanced map configuration options', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        cliPath,
+        'generate',
+        '--rooms',
+        '1',
+        '--room-layout',
+        'dense',
+        '--room-size',
+        'small',
+        '--room-shape',
+        'round',
+        '--corridor-type',
+        'maze',
+        '--no-allow-deadends',
+        '--seed',
+        'cli',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(0);
+    const d = JSON.parse(result.stdout) as Dungeon;
+    expect(Array.isArray(d.rooms)).toBe(true);
+  });
+
   it('falls back to generic system when unknown system specified', () => {
     const result = spawnSync(process.execPath, ['--import', 'tsx', cliPath, 'generate', '--rooms', '1', '--system', 'bogus'], { encoding: 'utf-8' });
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- extend CLI with room layout, size, shape, corridor type, and deadend controls to match GUI capabilities
- test CLI support for advanced map configuration options

## Testing
- `pnpm lint`
- `pnpm test` *(fails: TypeError: encounter is not iterable)*
- `pnpm test tests/cli.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a162d45408832f8e531a2c71280ddf