### PR TITLE
Remove mobile responsive design elements from GUI

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DungeonsOnAutomatic</title>
   
   <!-- Favicon -->
   <link rel="icon" type="image/x-icon" href="/assets/logo/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/logo/logo-small.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/logo/logo-small.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/logo/logo.png">
   <link rel="icon" type="image/svg+xml" href="/assets/logo/logo.svg">
   <style>
     :root {
@@ -214,7 +212,7 @@
     }
     .map-options {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      grid-template-columns: 1fr 1fr 1fr;
       gap: 20px;
       margin-bottom: 20px;
     }
@@ -380,7 +378,6 @@
       display: flex;
       gap: 10px;
       margin-bottom: 20px;
-      flex-wrap: wrap;
     }
     .data-manager-actions button {
       width: auto;
@@ -461,7 +458,6 @@
     .theme-selector {
       display: flex;
       gap: 15px;
-      flex-wrap: wrap;
       margin-top: 10px;
     }
     


### PR DESCRIPTION
## Summary
Remove mobile responsive design features per issue #105 since most GMs won't use this tool on mobile devices.

## Changes Made
- **Remove viewport meta tag** - Eliminates mobile optimization directive
- **Replace responsive grid** - Change from `repeat(auto-fit, minmax(250px, 1fr))` to fixed `1fr 1fr 1fr` desktop layout
- **Remove flex-wrap** - Eliminate mobile-friendly wrapping behaviors from containers
- **Remove Apple touch icon** - Remove mobile-specific icon link

## Rationale
The decision to remove mobile responsive design is based on the assessment that most GMs (Game Masters) will not use this dungeon generation tool on mobile devices. The tool is primarily designed for desktop use during game preparation and session planning.

## Impact
- Simplifies CSS and reduces complexity
- Maintains all core functionality on desktop
- GUI now optimized specifically for desktop screens
- No longer adapts to smaller screen sizes

## Test Plan
- [x] Verify layout works correctly on desktop browsers
- [x] Confirm all existing functionality remains intact
- [x] Validate no console errors introduced

Addresses: #105

🤖 Generated with [Claude Code](https://claude.ai/code)