### PR TITLE
feat: add CLI options for lock generation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -95,6 +95,12 @@ program
     "color palette (light, dark, sepia)",
     "light",
   )
+  .option(
+    "--lock-percentage <n>",
+    "fraction of doors to lock (0-1)",
+    (v) => parseFloat(v),
+  )
+  .option("--magical-locks", "allow magical locks")
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
@@ -161,7 +167,22 @@ program
               treasure: opts.treasureTag.length ? { requiredTags: opts.treasureTag } : undefined,
             }
           : undefined;
-      const enriched = await sys.enrich(d, { sources: opts.source, tags: tagOptions });
+      const lockOptions =
+        opts.lockPercentage !== undefined || opts.magicalLocks
+          ? {
+              lockOptions: {
+                ...(opts.lockPercentage !== undefined
+                  ? { lockPercentage: opts.lockPercentage }
+                  : {}),
+                ...(opts.magicalLocks ? { allowMagicalLocks: true } : {}),
+              },
+            }
+          : undefined;
+      const enriched = await sys.enrich(d, {
+        sources: opts.source,
+        tags: tagOptions,
+        ...(lockOptions || {}),
+      });
       
       // Handle exports
       if (opts.svg) {

--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -115,7 +115,20 @@ function getThreatRating(cer: number): 'fodder' | 'worthy' | 'boss' {
 export const dfrpg: SystemModule = {
   id: 'dfrpg',
   label: 'GURPS Dungeon Fantasy',
-  async enrich(d: Dungeon, opts?: { sources?: string[]; rng?: () => number; level?: number; useDFRPGTreasure?: boolean; useEnhancedTraps?: boolean; useEnvironmentalChallenges?: boolean; environmentComplexity?: 'minimal' | 'moderate' | 'challenging' | 'extreme'; tags?: TaggedSelectionOptions }): Promise<Dungeon> {
+  async enrich(
+    d: Dungeon,
+    opts?: {
+      sources?: string[];
+      rng?: () => number;
+      level?: number;
+      useDFRPGTreasure?: boolean;
+      useEnhancedTraps?: boolean;
+      useEnvironmentalChallenges?: boolean;
+      environmentComplexity?: 'minimal' | 'moderate' | 'challenging' | 'extreme';
+      tags?: TaggedSelectionOptions;
+      lockOptions?: LockGenerationOptions;
+    },
+  ): Promise<Dungeon> {
     const R = opts?.rng ?? Math.random;
     const encounters = { ...d.encounters };
     const dungeonLevel = opts?.level ?? 1;
@@ -413,7 +426,8 @@ export const dfrpg: SystemModule = {
     const lockGenerationOptions: LockGenerationOptions = {
       lockPercentage: 0.3, // 30% of doors get locks
       preferImportantDoors: true,
-      allowMagicalLocks: true // DFRPG supports magical locks
+      allowMagicalLocks: true, // DFRPG supports magical locks
+      ...(opts?.lockOptions || {}),
     };
 
     const keyPlacementOptions: KeyPlacementOptions = {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -98,6 +98,30 @@ describe('cli', () => {
     expect(enc?.treasure.every((t) => t.tags?.includes('coins'))).toBe(true);
   });
 
+  it('allows controlling lock generation via CLI', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        cliPath,
+        'generate',
+        '--rooms',
+        '2',
+        '--seed',
+        'cli',
+        '--system',
+        'dfrpg',
+        '--lock-percentage',
+        '1',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(0);
+    const d = JSON.parse(result.stdout) as Dungeon;
+    expect(d.doors.every((door) => door.status === 'locked')).toBe(true);
+  });
+
   it('supports hand-drawn svg output', () => {
     const result = spawnSync(
       process.execPath,

--- a/tests/locks.test.ts
+++ b/tests/locks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canKeyOpenDoor, checkDoorLock } from '../src/services/locks';
+import { canKeyOpenDoor, checkDoorLock, LockService } from '../src/services/locks';
 import {
   Dungeon,
   Door,
@@ -53,5 +53,24 @@ describe('checkDoorLock', () => {
     const result = checkDoorLock(dungeon, lockedDoor.id);
     expect(result.locked).toBe(true);
     expect(result.requiredKey).toBeUndefined();
+  });
+});
+
+describe('LockService', () => {
+  it('locks doors according to percentage and supports magical locks', () => {
+    const dungeon: Dungeon = {
+      seed: 's',
+      rooms: [],
+      corridors: [],
+      doors: [
+        { id: 'd1', type: 'normal', status: 'warded' },
+        { id: 'd2', type: 'normal', status: 'secret' },
+      ],
+    };
+    const service = new LockService(() => 0); // deterministic
+    const locks = service.generateLocks(dungeon, { lockPercentage: 1, allowMagicalLocks: true });
+    expect(locks.length).toBe(2);
+    expect(dungeon.doors.every((d) => d.status === 'locked')).toBe(true);
+    expect(locks.some((l) => l.quality === 'magical')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add `--lock-percentage` and `--magical-locks` CLI options
- allow DFRPG system to accept lock generation options
- cover lock service and CLI configuration with tests

## Testing
- `npm test` *(fails: PluginLoader and plugin CLI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db34ec60832f98b1e3dc58959ae4