### PR TITLE
feat: add DonJon TSV export plugin

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -104,6 +104,8 @@ program
   .option("--ascii", "render an ASCII map instead of JSON output")
   .option("--svg", "render an SVG map instead of JSON output")
   .option("--foundry", "output FoundryVTT-compatible JSON")
+  .option("--export-format <format>", "export using a plugin format")
+  .option("--donjon", "shorthand for --export-format donjon")
     .action(async (opts) => {
       if (opts.listSystems) {
         const loader = createDefaultPluginLoader();
@@ -183,7 +185,9 @@ program
         tags: tagOptions,
         ...(lockOptions || {}),
       });
-      
+
+      const exportFormat = opts.exportFormat || (opts.donjon ? 'donjon' : undefined);
+
       // Handle exports
       if (opts.svg) {
         let theme = lightTheme;
@@ -211,6 +215,33 @@ program
           // Fallback to original implementation
           console.error('Warning: ASCII plugin failed, using fallback:', err);
           process.stdout.write(renderAscii(enriched) + "\n");
+        }
+      } else if (exportFormat) {
+        const pluginLoader = createDefaultPluginLoader();
+        const infos = await pluginLoader.discover();
+        let handled = false;
+        for (const info of infos) {
+          try {
+            const plugin = await pluginLoader.load(info.metadata.id, { sandbox: false });
+            if (isExportPlugin(plugin) && plugin.supportedFormats.includes(exportFormat)) {
+              const result = await plugin.export(enriched, exportFormat);
+              const data: any = result.data;
+              if (typeof data === 'string' || data instanceof Buffer) {
+                process.stdout.write(data.toString() + (typeof data === 'string' ? "\n" : ""));
+              } else {
+                process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+              }
+              handled = true;
+            }
+          } catch {
+            /* ignore plugin load errors */
+          } finally {
+            await pluginLoader.unload(info.metadata.id).catch(() => {});
+          }
+          if (handled) break;
+        }
+        if (!handled) {
+          console.error(`No export plugin found for format: ${exportFormat}`);
         }
       } else if (opts.foundry) {
         process.stdout.write(JSON.stringify(exportFoundry(enriched), null, 2) + "\n");

--- a/src/plugins/donjon-export/index.ts
+++ b/src/plugins/donjon-export/index.ts
@@ -1,0 +1,102 @@
+import type { Dungeon } from '../../core/types';
+import type { ExportPlugin, ExportOptions, ExportResult, PluginMetadata } from '../../core/plugin-types';
+import { roomShapeService } from '../../services/room-shapes';
+
+function renderDonjonTSV(d: Dungeon): string {
+  const points: { x: number; y: number }[] = [];
+  for (const r of d.rooms) {
+    if (r.shape === 'rectangular' || !r.shapePoints) {
+      points.push({ x: r.x + r.w, y: r.y + r.h });
+    } else {
+      const bounds = roomShapeService.getRoomBounds(r);
+      points.push({ x: Math.ceil(bounds.maxX), y: Math.ceil(bounds.maxY) });
+    }
+  }
+  for (const c of d.corridors) {
+    for (const p of c.path) points.push(p);
+  }
+  const maxX = Math.max(0, ...points.map((p) => p.x)) + 1;
+  const maxY = Math.max(0, ...points.map((p) => p.y)) + 1;
+  const grid: string[][] = Array.from({ length: maxY }, () => Array(maxX).fill(''));
+
+  const markFloor = (x: number, y: number) => {
+    if (y >= 0 && y < maxY && x >= 0 && x < maxX) {
+      if (!grid[y][x]) grid[y][x] = 'F';
+    }
+  };
+
+  for (const r of d.rooms) {
+    if (r.shape === 'rectangular' || !r.shapePoints) {
+      for (let y = r.y; y < r.y + r.h; y++) {
+        for (let x = r.x; x < r.x + r.w; x++) {
+          markFloor(x, y);
+        }
+      }
+    } else {
+      const bounds = roomShapeService.getRoomBounds(r);
+      for (let y = Math.floor(bounds.minY); y <= Math.ceil(bounds.maxY); y++) {
+        for (let x = Math.floor(bounds.minX); x <= Math.ceil(bounds.maxX); x++) {
+          if (roomShapeService.isPointInRoom(r, x, y)) markFloor(x, y);
+        }
+      }
+    }
+  }
+
+  const doorCode = (from: {x:number;y:number}, to: {x:number;y:number}) => {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    if (dx === 1) return 'DR';
+    if (dx === -1) return 'DL';
+    if (dy === 1) return 'DB';
+    if (dy === -1) return 'DT';
+    return 'D';
+  };
+
+  for (const c of d.corridors) {
+    for (const p of c.path) markFloor(p.x, p.y);
+    if (c.path.length > 0) {
+      const start = c.doorStart || c.path[0];
+      const end = c.doorEnd || c.path[c.path.length - 1];
+      const next = c.path[1] || start;
+      const prev = c.path[c.path.length - 2] || end;
+      grid[start.y][start.x] = doorCode(start, next);
+      grid[end.y][end.x] = doorCode(prev, end);
+    }
+  }
+
+  return grid.map((row) => row.join('\t')).join('\n');
+}
+
+export const metadata: PluginMetadata = {
+  id: 'donjon-export',
+  version: '1.0.0',
+  description: 'Export dungeons as DonJon-compatible TSV files',
+  author: 'DOA Community',
+  tags: ['export', 'donjon', 'tsv', 'traditional'],
+};
+
+export const donjonExportPlugin: ExportPlugin = {
+  metadata,
+  supportedFormats: ['donjon', 'tsv'],
+
+  export(dungeon: Dungeon, format: string, options?: ExportOptions): ExportResult {
+    if (!this.supportedFormats.includes(format)) {
+      throw new Error(`Unsupported format: ${format}. Supported formats: ${this.supportedFormats.join(', ')}`);
+    }
+
+    const data = renderDonjonTSV(dungeon);
+
+    return {
+      format,
+      data,
+      contentType: 'text/tab-separated-values',
+      filename: options?.filename || `dungeon.${format}`,
+    };
+  },
+
+  initialize() {},
+  cleanup() {},
+  getDefaultConfig() { return {}; },
+};
+
+export default donjonExportPlugin;

--- a/src/plugins/donjon-export/package.json
+++ b/src/plugins/donjon-export/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@doa/donjon-export",
+  "version": "1.0.0",
+  "description": "DonJon TSV export plugin for Dungeons on Automatic",
+  "main": "index.ts",
+  "type": "module",
+  "doaPlugin": {
+    "id": "donjon-export",
+    "type": "export",
+    "description": "Export dungeons as DonJon-compatible TSV files",
+    "author": "DOA Community",
+    "tags": ["export", "donjon", "tsv", "traditional"]
+  },
+  "peerDependencies": {
+    "@doa/core": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add DonJon TSV export plugin for generating tab-separated dungeon maps
- expose plugin formats through --export-format and --donjon CLI flags

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Unexpected token 'D' and multiple plugin loader test failures)*


------
https://chatgpt.com/codex/tasks/task_e_68a5df53fd30832f9a24a08a202b25e3