### PR TITLE
feat: add hex grid rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pnpm doa generate --rooms=5 --theme=generic-undead --monster-tag=undead --trap-t
 pnpm doa generate --rooms=8 --room-shape=diverse --corridor-width=2
 pnpm doa generate --rooms=6 --room-shape=hex-preference --corridor-type=winding
 pnpm doa generate --rooms=4 --room-shape=circular-preference --layout-type=round
+pnpm doa generate --rooms=5 --svg --map-style hex > hex.svg
 ```
 
 Use `--width` and `--height` to control the overall map dimensions.

--- a/docs/hex-grid.md
+++ b/docs/hex-grid.md
@@ -1,0 +1,24 @@
+# Hex Grid Coordinate System
+
+The hexagonal map style uses **axial coordinates** with a pointy-top orientation.
+
+For a hex with axial coordinates `(q, r)` and hex size `s` (the radius):
+
+- Pixel X: `x = s * sqrt(3) * (q + r/2)`
+- Pixel Y: `y = s * 1.5 * r`
+
+Distance between two hexes `a` and `b` is:
+
+```
+(|aq - bq| + |aq + ar - bq - br| + |ar - br|) / 2
+```
+
+Neighboring hexes are obtained by adding one of the six direction vectors:
+
+```
+[ {q:1,r:0}, {q:1,r:-1}, {q:0,r:-1},
+  {q:-1,r:0}, {q:-1,r:1}, {q:0,r:1} ]
+```
+
+These utilities are available from `src/services/hex-grid.ts` and are used by the
+SVG renderer when `--map-style hex` is selected.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -76,7 +76,7 @@ program
   )
   .option(
     "--map-style <style>",
-    "map rendering style (classic, hand-drawn)",
+    "map rendering style (classic, hand-drawn, hex)",
     "classic",
   )
   .option(

--- a/src/services/hex-grid.ts
+++ b/src/services/hex-grid.ts
@@ -1,0 +1,72 @@
+export interface Hex {
+  q: number;
+  r: number;
+}
+
+/** Convert axial hex coordinates to pixel coordinates (pointy-top orientation) */
+export function axialToPixel(hex: Hex, size: number): { x: number; y: number } {
+  const x = size * Math.sqrt(3) * (hex.q + hex.r / 2);
+  const y = size * 1.5 * hex.r;
+  return { x, y };
+}
+
+/** Convert pixel coordinates to axial hex coordinates (pointy-top orientation) */
+export function pixelToAxial(x: number, y: number, size: number): Hex {
+  const q = ((Math.sqrt(3) / 3) * x - (1 / 3) * y) / size;
+  const r = (2 / 3 * y) / size;
+  return hexRound({ q, r });
+}
+
+/** Round fractional axial coordinates to nearest hex */
+export function hexRound(h: Hex): Hex {
+  let x = h.q;
+  let z = h.r;
+  let y = -x - z;
+
+  let rx = Math.round(x);
+  let ry = Math.round(y);
+  let rz = Math.round(z);
+
+  const xDiff = Math.abs(rx - x);
+  const yDiff = Math.abs(ry - y);
+  const zDiff = Math.abs(rz - z);
+
+  if (xDiff > yDiff && xDiff > zDiff) {
+    rx = -ry - rz;
+  } else if (yDiff > zDiff) {
+    ry = -rx - rz;
+  } else {
+    rz = -rx - ry;
+  }
+
+  return { q: rx, r: rz };
+}
+
+/** Distance between two hexes */
+export function hexDistance(a: Hex, b: Hex): number {
+  return (
+    Math.abs(a.q - b.q) +
+    Math.abs(a.q + a.r - b.q - b.r) +
+    Math.abs(a.r - b.r)
+  ) / 2;
+}
+
+const DIRECTIONS: Hex[] = [
+  { q: 1, r: 0 },
+  { q: 1, r: -1 },
+  { q: 0, r: -1 },
+  { q: -1, r: 0 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 },
+];
+
+/** Return neighbour in given direction (0-5) */
+export function hexNeighbor(h: Hex, direction: number): Hex {
+  const dir = DIRECTIONS[((direction % 6) + 6) % 6];
+  return { q: h.q + dir.q, r: h.r + dir.r };
+}
+
+/** Return all neighbouring hexes */
+export function hexNeighbors(h: Hex): Hex[] {
+  return DIRECTIONS.map((d) => ({ q: h.q + d.q, r: h.r + d.r }));
+}

--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -1,5 +1,6 @@
 import { Dungeon, Room } from "../core/types";
 import { roomShapeService } from "./room-shapes";
+import { axialToPixel } from "./hex-grid";
 
 export interface RenderTheme {
   /** Color of the SVG background */
@@ -40,13 +41,15 @@ export const sepiaTheme: RenderTheme = {
 
 export interface RenderOptions {
   /** Style variant for SVG rendering */
-  style?: "classic" | "hand-drawn";
+  style?: "classic" | "hand-drawn" | "hex";
   /** Show subtle grid background for technical pen style */
   showGrid?: boolean;
   /** Line wobble intensity for hand-drawn style (0-2) */
   wobbleIntensity?: number;
   /** Wall thickness multiplier for hand-drawn style */
   wallThickness?: number;
+  /** Radius of a single hex in pixels for hex style */
+  hexSize?: number;
 }
 
 /**
@@ -355,13 +358,20 @@ export async function renderSvg(
   theme: RenderTheme = lightTheme,
   opts: RenderOptions = {},
 ): Promise<string> {
-  const cell = 20; // pixel size of a single grid square
   const style = opts.style ?? "classic";
   const showGrid = opts.showGrid ?? false;
+  const hexSize = opts.hexSize ?? 20;
   const wobbleIntensity = opts.wobbleIntensity ?? 1;
   const wallThickness = opts.wallThickness ?? 1;
   const rng = d.rng ?? Math.random;
-  
+
+  // Built-in hex rendering
+  if (style === "hex") {
+    return renderHexSvg(d, theme, { hexSize, showGrid });
+  }
+
+  const cell = 20; // pixel size of a single grid square
+
   // Try to use render plugin first if style is supported (Node.js only)
   if (style !== "classic" && typeof window === 'undefined') {
     try {
@@ -460,6 +470,106 @@ export async function renderSvg(
       );
     }
   });
+
+  parts.push("</svg>");
+  return parts.join("");
+}
+
+interface HexRenderOptions {
+  hexSize: number;
+  showGrid: boolean;
+}
+
+function hexPolygonPoints(cx: number, cy: number, size: number): string {
+  const pts: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 180) * (60 * i - 30);
+    const x = cx + size * Math.cos(angle);
+    const y = cy + size * Math.sin(angle);
+    pts.push(`${x},${y}`);
+  }
+  return pts.join(" ");
+}
+
+function renderHexSvg(
+  d: Dungeon,
+  theme: RenderTheme,
+  opts: HexRenderOptions,
+): string {
+  const size = opts.hexSize;
+  const cells: { q: number; r: number; type: "room" | "corridor" }[] = [];
+
+  for (const r of d.rooms) {
+    for (let y = r.y; y < r.y + r.h; y++) {
+      for (let x = r.x; x < r.x + r.w; x++) {
+        cells.push({ q: x, r: y, type: "room" });
+      }
+    }
+  }
+  for (const c of d.corridors) {
+    for (const p of c.path) {
+      cells.push({ q: p.x, r: p.y, type: "corridor" });
+    }
+  }
+
+  if (!cells.length) {
+    return '<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" />';
+  }
+
+  let minQ = Infinity, maxQ = -Infinity, minR = Infinity, maxR = -Infinity;
+  for (const c of cells) {
+    if (c.q < minQ) minQ = c.q;
+    if (c.q > maxQ) maxQ = c.q;
+    if (c.r < minR) minR = c.r;
+    if (c.r > maxR) maxR = c.r;
+  }
+
+  const hexWidth = Math.sqrt(3) * size;
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (let q = minQ - 1; q <= maxQ + 1; q++) {
+    for (let r = minR - 1; r <= maxR + 1; r++) {
+      const { x, y } = axialToPixel({ q, r }, size);
+      const left = x - hexWidth / 2;
+      const right = x + hexWidth / 2;
+      const top = y - size;
+      const bottom = y + size;
+      if (left < minX) minX = left;
+      if (right > maxX) maxX = right;
+      if (top < minY) minY = top;
+      if (bottom > maxY) maxY = bottom;
+    }
+  }
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const parts: string[] = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    `<rect x="0" y="0" width="${width}" height="${height}" fill="${theme.background}"/>`,
+  ];
+
+  if (opts.showGrid) {
+    for (let r = minR - 1; r <= maxR + 1; r++) {
+      for (let q = minQ - 1; q <= maxQ + 1; q++) {
+        const { x, y } = axialToPixel({ q, r }, size);
+        const cx = x - minX;
+        const cy = y - minY;
+        const pts = hexPolygonPoints(cx, cy, size);
+        parts.push(
+          `<polygon class="hex-grid" points="${pts}" fill="none" stroke="${theme.corridorFill}" stroke-width="0.5"/>`,
+        );
+      }
+    }
+  }
+
+  for (const cell of cells) {
+    const { x, y } = axialToPixel({ q: cell.q, r: cell.r }, size);
+    const cx = x - minX;
+    const cy = y - minY;
+    const pts = hexPolygonPoints(cx, cy, size);
+    const fill = cell.type === "room" ? theme.roomFill : theme.corridorFill;
+    const stroke = cell.type === "room" ? theme.roomStroke : "none";
+    parts.push(`<polygon class="hex-cell" points="${pts}" fill="${fill}" stroke="${stroke}"/>`);
+  }
 
   parts.push("</svg>");
   return parts.join("");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -147,5 +147,26 @@ describe('cli', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toMatch(/font-family="cursive"/);
   });
+
+  it('supports hex SVG map style', async () => {
+    const result = spawnSync(
+      'pnpm',
+      [
+        'tsx',
+        cliPath,
+        'generate',
+        '--rooms',
+        '1',
+        '--seed',
+        'cli',
+        '--svg',
+        '--map-style',
+        'hex',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/class="hex-cell"/);
+  });
 });
 

--- a/tests/hex-grid.test.ts
+++ b/tests/hex-grid.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { axialToPixel, pixelToAxial, hexDistance, hexNeighbor } from '../src/services/hex-grid';
+
+describe('hex-grid utilities', () => {
+  it('converts axial to pixel and back', () => {
+    const h = { q: 2, r: -1 };
+    const size = 10;
+    const px = axialToPixel(h, size);
+    const h2 = pixelToAxial(px.x, px.y, size);
+    expect(h2.q).toBe(h.q);
+    expect(h2.r).toBe(h.r);
+  });
+
+  it('computes hex distance', () => {
+    const a = { q: 0, r: 0 };
+    const b = { q: 2, r: -1 };
+    expect(hexDistance(a, b)).toBe(2);
+  });
+
+  it('finds neighboring hex', () => {
+    const h = { q: 0, r: 0 };
+    const n = hexNeighbor(h, 0);
+    expect(n).toEqual({ q: 1, r: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- support `--map-style hex` in CLI
- add axial hex grid utilities and rendering path
- document hex coordinate system

## Testing
- `pnpm test` *(fails: Invalid plugin metadata ...; Plugin not found ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dfbd17ec832fb5ef22d0975d8e57