### PR TITLE
feat(gui): add interactive links between map and key

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -170,6 +170,15 @@
       border-radius: 4px;
       overflow: hidden;
     }
+    .room-number,
+    .door-icon,
+    .key-icon {
+      cursor: pointer;
+    }
+    .map-highlight {
+      stroke: var(--accent-warning);
+      stroke-width: 3;
+    }
     .room-key {
       margin-top: 20px;
       padding: 15px;

--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -531,6 +531,8 @@ async function generate(): Promise<void> {
     
     roomKeyEl.innerHTML = fullRoomKey;
 
+    setupMapKeyInteractions(mapEl, roomKeyEl);
+
     // Update download link
     const blob = new Blob([svg], { type: 'image/svg+xml' });
     downloadEl.href = URL.createObjectURL(blob);
@@ -1278,6 +1280,58 @@ function importPresets(file: File): void {
   };
   
   reader.readAsText(file);
+}
+
+function setupMapKeyInteractions(mapEl: HTMLElement, roomKeyEl: HTMLElement): void {
+  const svg = mapEl.querySelector('svg');
+  if (!svg) return;
+
+  svg.querySelectorAll<SVGTextElement>('text[data-room]').forEach(el => {
+    el.addEventListener('click', () => {
+      const num = el.getAttribute('data-room');
+      const target = roomKeyEl.querySelector<HTMLElement>(`#room-${num}`);
+      target?.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  svg.querySelectorAll<SVGGraphicsElement>('.door-icon').forEach(el => {
+    el.addEventListener('click', () => {
+      const id = el.getAttribute('data-door');
+      const target = roomKeyEl.querySelector<HTMLElement>(`#door-${id}`);
+      target?.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  svg.querySelectorAll<SVGGraphicsElement>('.key-icon').forEach(el => {
+    el.addEventListener('click', () => {
+      const id = el.getAttribute('data-key');
+      const target = roomKeyEl.querySelector<HTMLElement>(`#key-${id}`);
+      target?.scrollIntoView({ behavior: 'smooth' });
+    });
+  });
+
+  const highlight = (element: SVGGraphicsElement) => {
+    svg.querySelectorAll('.map-highlight').forEach(e => e.classList.remove('map-highlight'));
+    element.classList.add('map-highlight');
+    element.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+  };
+
+  roomKeyEl.querySelectorAll<HTMLElement>('section.room').forEach(section => {
+    const num = section.getAttribute('data-room');
+    section.addEventListener('click', () => {
+      const el = svg.querySelector<SVGGraphicsElement>(`.room-shape[data-room="${num}"]`);
+      if (el) highlight(el);
+    });
+  });
+
+  roomKeyEl.querySelectorAll<HTMLElement>('[data-key]').forEach(keyEl => {
+    const id = keyEl.getAttribute('data-key');
+    keyEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const el = svg.querySelector<SVGGraphicsElement>(`.key-icon[data-key="${id}"]`);
+      if (el) highlight(el);
+    });
+  });
 }
 
 function downloadJSON(json: string, filename: string): void {

--- a/src/services/render.ts
+++ b/src/services/render.ts
@@ -434,7 +434,7 @@ export async function renderSvg(
         const edge = doorEdge(fromRoom, doorPosition);
         if (edge)
           parts.push(
-            `<line x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
+            `<line class="door-icon" data-door="${c.id}-start" x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
           );
       }
       if (toRoom) {
@@ -442,7 +442,7 @@ export async function renderSvg(
         const edge = doorEdge(toRoom, doorPosition);
         if (edge)
           parts.push(
-            `<line x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
+            `<line class="door-icon" data-door="${c.id}-end" x1="${edge.x1 * cell}" y1="${edge.y1 * cell}" x2="${edge.x2 * cell}" y2="${edge.y2 * cell}" stroke="${theme.roomStroke}" stroke-width="${cell * 0.2}"/>`,
           );
       }
     }
@@ -451,24 +451,34 @@ export async function renderSvg(
   d.rooms.forEach((r, i) => {
     if (r.shape === "rectangular" || !r.shapePoints) {
       parts.push(
-        `<rect x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="${theme.roomFill}" stroke="${theme.roomStroke}"/>`,
+        `<rect class="room-shape" data-room="${i + 1}" x="${r.x * cell}" y="${r.y * cell}" width="${r.w * cell}" height="${r.h * cell}" fill="${theme.roomFill}" stroke="${theme.roomStroke}"/>`,
       );
       const cx = (r.x + r.w / 2) * cell;
       const cy = (r.y + r.h / 2) * cell;
       parts.push(
-        `<text x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}" fill="${theme.textFill}">${i + 1}</text>`,
+        `<text class="room-number" data-room="${i + 1}" x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}" fill="${theme.textFill}">${i + 1}</text>`,
       );
     } else {
       const points = r.shapePoints!.map((p) => `${p.x * cell},${p.y * cell}`).join(" ");
       parts.push(
-        `<polygon points="${points}" fill="${theme.roomFill}" stroke="${theme.roomStroke}"/>`,
+        `<polygon class="room-shape" data-room="${i + 1}" points="${points}" fill="${theme.roomFill}" stroke="${theme.roomStroke}"/>`,
       );
       const cx = r.x * cell;
       const cy = r.y * cell;
       parts.push(
-        `<text x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}" fill="${theme.textFill}">${i + 1}</text>`,
+        `<text class="room-number" data-room="${i + 1}" x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.6}" fill="${theme.textFill}">${i + 1}</text>`,
       );
     }
+  });
+
+  (d.keyItems || []).forEach(key => {
+    const room = d.rooms.find(r => r.id === key.locationId);
+    if (!room) return;
+    const cx = (room.x + room.w / 2) * cell;
+    const cy = (room.y + room.h / 2) * cell - cell * 0.4;
+    parts.push(
+      `<text class="key-icon" data-key="${key.id}" x="${cx}" y="${cy}" text-anchor="middle" dominant-baseline="middle" font-size="${cell * 0.5}" fill="${theme.textFill}">&#x1F511;</text>`
+    );
   });
 
   parts.push("</svg>");

--- a/src/services/room-key.ts
+++ b/src/services/room-key.ts
@@ -195,7 +195,7 @@ export function htmlRoomDetails(d: Dungeon, details: Record<ID, RoomDetail>): st
         }
       }
       
-      const parts: string[] = [`<section class="room"><h3>${roomTitle}</h3>`];
+      const parts: string[] = [`<section class="room" id="room-${index + 1}" data-room="${index + 1}"><h3>${roomTitle}</h3>`];
       
       // Add room type as a subtitle for special rooms
       if (room.kind === 'special') {
@@ -295,13 +295,13 @@ export function htmlRoomDetails(d: Dungeon, details: Record<ID, RoomDetail>): st
         const keyDetails = keysInRoom.map(key => {
           // Find which door this key unlocks
           const unlockedDoor = d.doors?.find(door => door.id === key.doorId);
-          const doorDescription = unlockedDoor 
-            ? `unlocks ${unlockedDoor.type} door ${unlockedDoor.id}` 
+          const doorDescription = unlockedDoor
+            ? `unlocks ${unlockedDoor.type} door ${unlockedDoor.id}`
             : `unlocks door ${key.doorId}`;
-          
-          return `<strong>${key.name}</strong> (${doorDescription})${key.description ? ` - ${key.description}` : ''}`;
+
+          return `<span id="key-${key.id}" data-key="${key.id}"><strong>${key.name}</strong> (${doorDescription})${key.description ? ` - ${key.description}` : ''}</span>`;
         });
-        
+
         parts.push(`<p><strong>Keys Found:</strong> ${keyDetails.join(', ')}</p>`);
       }
 


### PR DESCRIPTION
## Summary
- add CSS and data attributes for clickable map elements
- render rooms, doors and keys with identifiers
- wire up map interactions that scroll and highlight corresponding key entries

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Playwright tests and CLI expectations)*


------
https://chatgpt.com/codex/tasks/task_e_68a613f4bb80832f9b26ea063752432b