### PR TITLE
Fix minimap rendering and remove map scrollbars

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -168,11 +168,16 @@
       margin-top: 20px;
       border: 1px solid var(--border-primary);
       border-radius: 4px;
-      overflow: auto;
+      overflow: scroll;
       position: relative;
       max-height: 70vh;
       cursor: grab;
       user-select: none;
+      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: none; /* Firefox */
+    }
+    .map-container::-webkit-scrollbar {
+      display: none; /* Chrome, Safari */
     }
     .map-container:active {
       cursor: grabbing;

--- a/apps/gui/src/main.ts
+++ b/apps/gui/src/main.ts
@@ -1366,53 +1366,47 @@ let minimapState: MinimapState = {
   containerHeight: 126 // 150 - 24 (header height)
 };
 
+let minimapInitialized = false;
+
 function createMinimap(originalSvg: SVGElement): void {
   const minimapContainer = document.getElementById('minimap-svg-container');
   const minimap = document.getElementById('minimap');
-  
+
   if (!minimapContainer || !minimap || !originalSvg) return;
 
-  // Clone the original SVG for the minimap
-  const clonedSvg = originalSvg.cloneNode(true) as SVGElement;
-  clonedSvg.classList.add('minimap-svg');
-  clonedSvg.removeAttribute('id'); // Avoid duplicate IDs
-  
-  // Get original SVG dimensions
-  const originalViewBox = originalSvg.getAttribute('viewBox');
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(originalSvg);
+
   const originalWidth = parseFloat(originalSvg.getAttribute('width') || '800');
   const originalHeight = parseFloat(originalSvg.getAttribute('height') || '600');
-  
+
   minimapState.svgWidth = originalWidth;
   minimapState.svgHeight = originalHeight;
-  
-  // Calculate scale to fit minimap container
+
   const scaleX = minimapState.containerWidth / originalWidth;
   const scaleY = minimapState.containerHeight / originalHeight;
   minimapState.scale = Math.min(scaleX, scaleY);
-  
-  // Set minimap SVG dimensions
+
   const minimapWidth = originalWidth * minimapState.scale;
   const minimapHeight = originalHeight * minimapState.scale;
-  
-  clonedSvg.setAttribute('width', minimapWidth.toString());
-  clonedSvg.setAttribute('height', minimapHeight.toString());
-  
-  if (originalViewBox) {
-    clonedSvg.setAttribute('viewBox', originalViewBox);
-  }
-  
-  // Clear previous content and add new minimap
+
+  const img = document.createElement('img');
+  img.src = 'data:image/svg+xml,' + encodeURIComponent(svgString);
+  img.classList.add('minimap-svg');
+  img.setAttribute('width', minimapWidth.toString());
+  img.setAttribute('height', minimapHeight.toString());
+
   minimapContainer.innerHTML = '';
-  minimapContainer.appendChild(clonedSvg);
-  
-  // Show minimap
+  minimapContainer.appendChild(img);
+
   minimap.style.display = 'block';
   minimapState.isVisible = true;
-  
-  // Setup minimap interactions
-  setupMinimapInteractions();
-  
-  // Initial viewport rectangle update
+
+  if (!minimapInitialized) {
+    setupMinimapInteractions();
+    minimapInitialized = true;
+  }
+
   updateMinimapViewport();
 }
 

--- a/tests/e2e/minimap.spec.ts
+++ b/tests/e2e/minimap.spec.ts
@@ -17,7 +17,7 @@ test.describe('Minimap Navigation', () => {
     // Check minimap components
     await expect(page.locator('.minimap-header')).toBeVisible();
     await expect(page.locator('#minimap-toggle')).toBeVisible();
-    await expect(page.locator('#minimap-svg-container svg')).toBeVisible();
+    await expect(page.locator('#minimap-svg-container img')).toBeVisible();
     await expect(page.locator('#minimap-viewport')).toBeVisible();
   });
 
@@ -162,7 +162,7 @@ test.describe('Minimap Navigation', () => {
     
     // Minimap should still be visible and functional
     await expect(page.locator('#minimap')).toBeVisible();
-    await expect(page.locator('#minimap-svg-container svg')).toBeVisible();
+    await expect(page.locator('#minimap-svg-container img')).toBeVisible();
     
     // Test navigation still works
     const minimapSvg = page.locator('#minimap-svg-container');
@@ -226,18 +226,18 @@ test.describe('Minimap Navigation', () => {
     // Note: In current implementation, minimap state resets on generation
     // This test documents the current behavior - minimap will be expanded again
     await expect(page.locator('#minimap')).toBeVisible();
-    await expect(page.locator('#minimap-svg-container svg')).toBeVisible();
+    await expect(page.locator('#minimap-svg-container img')).toBeVisible();
   });
 
   test('should display correct minimap proportions', async ({ page }) => {
     const mainSvg = page.locator('#map-content svg');
-    const minimapSvg = page.locator('#minimap-svg-container svg');
-    
-    // Get dimensions of both SVGs
+    const minimapImg = page.locator('#minimap-svg-container img');
+
+    // Get dimensions of both images
     const mainWidth = await mainSvg.evaluate(el => el.getBoundingClientRect().width);
     const mainHeight = await mainSvg.evaluate(el => el.getBoundingClientRect().height);
-    const minimapWidth = await minimapSvg.evaluate(el => el.getBoundingClientRect().width);
-    const minimapHeight = await minimapSvg.evaluate(el => el.getBoundingClientRect().height);
+    const minimapWidth = await minimapImg.evaluate(el => el.getBoundingClientRect().width);
+    const minimapHeight = await minimapImg.evaluate(el => el.getBoundingClientRect().height);
     
     // Calculate aspect ratios
     const mainAspectRatio = mainWidth / mainHeight;


### PR DESCRIPTION
## Summary
- render minimap using an image cloned from the main SVG and avoid duplicate initialization
- hide map scrollbars for a cleaner panning experience
- adjust minimap e2e tests for new image-based minimap

## Testing
- `pnpm lint`
- `pnpm test` (fails: expected false to be true, Playwright tests invoked)
- `pnpm test:e2e` (served HTML report; command interrupted)

------
https://chatgpt.com/codex/tasks/task_e_68a63bd1dd4c832f84ed6c0e1c4f4228