### PR TITLE
Fix minimap position to follow viewing pane

### DIFF
--- a/apps/gui/index.html
+++ b/apps/gui/index.html
@@ -233,7 +233,7 @@
       transition: transform 0.2s ease;
     }
     .minimap {
-      position: absolute;
+      position: fixed;
       bottom: 10px;
       right: 10px;
       width: 200px;


### PR DESCRIPTION
## Summary
- Keep minimap pinned to bottom-right of the viewport using CSS `position: fixed`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:e2e` *(fails: browser launch missing dependencies, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a6429ed60c832fbc355c1349015d69