### PR TITLE
Use sequential door numbers

### DIFF
--- a/src/services/doors.ts
+++ b/src/services/doors.ts
@@ -1,15 +1,22 @@
 import { Door } from '../core/types';
-import { id, pick } from './random';
+import { pick } from './random';
 
 export const DOOR_TYPES: Door['type'][] = ['normal', 'arch', 'portcullis', 'hole'];
 export const DOOR_STATUSES: Door['status'][] = ['locked', 'trapped', 'barred', 'jammed', 'warded', 'secret'];
+
+// Track how many doors have been generated for each RNG so we can
+// assign friendly sequential numbers instead of random UUIDs.
+const doorCounters = new WeakMap<() => number, number>();
 
 export function generateDoor(
   r: () => number,
   endpoints: { fromRoom?: string; toRoom?: string; location?: { x: number; y: number } } = {},
 ): Door {
+  const next = (doorCounters.get(r) || 0) + 1;
+  doorCounters.set(r, next);
+
   return {
-    id: id('door', r),
+    id: `door-${next}`,
     type: pick(r, DOOR_TYPES),
     status: pick(r, DOOR_STATUSES),
     ...endpoints,

--- a/tests/doors.test.ts
+++ b/tests/doors.test.ts
@@ -24,8 +24,9 @@ describe('doors', () => {
   it('generateDoor produces consistent ids with same RNG', () => {
     const r1 = rng('doorIds');
     const r2 = rng('doorIds');
-    const ids1 = Array.from({ length: 10 }, () => generateDoor(r1, { fromRoom: 'X' }).id);
-    const ids2 = Array.from({ length: 10 }, () => generateDoor(r2, { fromRoom: 'X' }).id);
+    const ids1 = Array.from({ length: 5 }, () => generateDoor(r1, { fromRoom: 'X' }).id);
+    const ids2 = Array.from({ length: 5 }, () => generateDoor(r2, { fromRoom: 'X' }).id);
+    expect(ids1).toEqual(['door-1', 'door-2', 'door-3', 'door-4', 'door-5']);
     expect(ids1).toEqual(ids2);
   });
 


### PR DESCRIPTION
## Summary
- issue sequential ids for doors so keys reference friendly numbers instead of random strings
- adjust door tests to confirm deterministic numbering

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a64321f174832f9a8a9e181ecfe6c3