### PR TITLE
Fix DFRPG treasure formatting consistency

### DIFF
--- a/src/systems/dfrpg/index.ts
+++ b/src/systems/dfrpg/index.ts
@@ -311,26 +311,18 @@ export const dfrpg: SystemModule = {
             const hoardSize = roomDanger >= 3 ? 'large' : roomDanger >= 2 ? 'medium' : 'small';
             const treasureHoard = treasureGenerator.generateTreasureHoard(dungeonLevel, hoardSize);
             
-            // Convert to simple treasure format for compatibility
-            if (treasureHoard.coins.totalValue > 0) {
-              treasure.push({ 
-                kind: 'coins', 
-                valueHint: `$${treasureHoard.coins.totalValue} (${treasureHoard.coins.totalWeight.toFixed(1)} lbs)` 
-              });
-            }
-            
-            treasureHoard.magicItems.forEach(item => {
-              treasure.push({
-                kind: 'magic',
-                valueHint: `${item.name} ($${item.value}, ${item.weight} lbs) - ${item.quirks?.join(', ') || 'No quirks'}`
-              });
+            // Create a single detailed treasure entry using the DFRPG treasure formatter
+            const treasureDescription = treasureGenerator.formatTreasureDescription(treasureHoard, {
+              format: 'detailed',
+              showReferences: false,
+              showWeights: true,
+              useIcons: true,
+              groupByType: true
             });
             
-            treasureHoard.mundaneItems.forEach(item => {
-              treasure.push({
-                kind: item.category === 'art' ? 'art' : item.category === 'gem' ? 'gems' : 'other',
-                valueHint: `${item.name} ($${item.value}, ${item.weight} lbs)${item.description ? ' - ' + item.description : ''}`
-              });
+            treasure.push({
+              kind: 'other',
+              valueHint: treasureDescription.replace(/\n/g, '\n  ') // Indent for better formatting
             });
           } else {
             // Legacy simple treasure


### PR DESCRIPTION
## Summary
- Fixes inconsistent treasure formatting in DFRPG system
- Ensures all rooms show detailed treasure format with icons and categorization
- Eliminates mix of simple coin descriptions and detailed breakdowns

## Problem
The DFRPG treasure generator was producing inconsistent output:
- Some rooms: `Treasure: coins ($1082)`
- Others: `Treasure: 💰 Treasure (Total: $1616, 12.5 lbs)...`

## Solution
- Use `DFRPGTreasureGenerator.formatTreasureDescription()` for consistent formatting
- Create single detailed treasure entries instead of multiple fragmented ones
- All treasure now includes icons, categorized items, and full weight/value details

## Test plan
- [x] Generated multiple test dungeons with DFRPG system
- [x] Verified all rooms with treasure use consistent detailed format
- [x] Confirmed DFRPG-specific tests pass
- [x] Checked treasure displays properly in both CLI and expected GUI output

🤖 Generated with [Claude Code](https://claude.ai/code)