### PR TITLE
Add core map generation scaffolding

### DIFF
--- a/src/CoreLogic/Generation/WfcService.cs
+++ b/src/CoreLogic/Generation/WfcService.cs
@@ -1,0 +1,32 @@
+using System;
+using DungeonsOnAutomatic.CoreLogic.Map;
+
+namespace DungeonsOnAutomatic.CoreLogic.Generation;
+
+/// <summary>
+/// Basic scaffold for the Wave Function Collapse solver.
+/// TODO: Replace random filler with actual constraint propagation.
+/// </summary>
+public class WfcService
+{
+    private readonly Random _random = new();
+
+    /// <summary>
+    /// Generates a new map based on the provided dimensions.
+    /// </summary>
+    public MapData Generate(int width, int height)
+    {
+        var map = new MapData(width, height);
+
+        // TODO: Implement real WFC algorithm.
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                map[x, y] = new MapTile { Tag = _random.Next(2) == 0 ? "Floor" : "Wall" };
+            }
+        }
+
+        return map;
+    }
+}

--- a/src/CoreLogic/Map/MapData.cs
+++ b/src/CoreLogic/Map/MapData.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace DungeonsOnAutomatic.CoreLogic.Map;
+
+/// <summary>
+/// Primary data structures describing a generated map.
+/// TODO: Support multiple layers and metadata.
+/// </summary>
+public class MapData
+{
+    private readonly MapTile[,] _tiles;
+
+    public int Width { get; }
+    public int Height { get; }
+
+    public MapData(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        _tiles = new MapTile[width, height];
+    }
+
+    public MapTile this[int x, int y]
+    {
+        get => _tiles[x, y];
+        set => _tiles[x, y] = value;
+    }
+
+    public IEnumerable<MapTile> AllTiles()
+    {
+        for (int y = 0; y < Height; y++)
+        {
+            for (int x = 0; x < Width; x++)
+            {
+                yield return _tiles[x, y];
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Simple tile representation with a tag identifier.
+/// </summary>
+public class MapTile
+{
+    /// <summary>
+    /// High level category for the tile such as Floor or Wall.
+    /// TODO: Expand to support multiple tags and properties.
+    /// </summary>
+    public string Tag { get; set; } = string.Empty;
+}

--- a/src/CoreLogic/Tagging/TaggingSystem.cs
+++ b/src/CoreLogic/Tagging/TaggingSystem.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace DungeonsOnAutomatic.CoreLogic.Tagging;
+
+/// <summary>
+/// Simple tag container that tracks affinities and antagonisms.
+/// TODO: Flesh out serialization and conflict resolution rules.
+/// </summary>
+public class TaggingSystem
+{
+    private readonly Dictionary<string, HashSet<string>> _affinities = new();
+    private readonly Dictionary<string, HashSet<string>> _antagonisms = new();
+
+    /// <summary>
+    /// Registers that <paramref name="tag"/> has an affinity with <paramref name="other"/>.
+    /// </summary>
+    public void AddAffinity(string tag, string other)
+    {
+        if (!_affinities.TryGetValue(tag, out var set))
+        {
+            set = new HashSet<string>();
+            _affinities[tag] = set;
+        }
+
+        set.Add(other);
+    }
+
+    /// <summary>
+    /// Registers that <paramref name="tag"/> is antagonistic with <paramref name="other"/>.
+    /// </summary>
+    public void AddAntagonism(string tag, string other)
+    {
+        if (!_antagonisms.TryGetValue(tag, out var set))
+        {
+            set = new HashSet<string>();
+            _antagonisms[tag] = set;
+        }
+
+        set.Add(other);
+    }
+
+    /// <summary>
+    /// Checks if <paramref name="tag"/> and <paramref name="other"/> are considered compatible.
+    /// Currently only ensures they are not antagonistic.
+    /// TODO: Add affinity scoring once generation uses weights.
+    /// </summary>
+    public bool AreCompatible(string tag, string other)
+    {
+        return !_antagonisms.TryGetValue(tag, out var set) || !set.Contains(other);
+    }
+}

--- a/src/GodotGame/Godot/MapRenderer.cs
+++ b/src/GodotGame/Godot/MapRenderer.cs
@@ -1,0 +1,40 @@
+using Godot;
+using DungeonsOnAutomatic.CoreLogic.Map;
+
+namespace DungeonsOnAutomatic.GodotGame.Godot;
+
+/// <summary>
+/// Renders <see cref="MapData"/> into the Godot scene.
+/// TODO: Replace placeholder squares with textured tiles.
+/// </summary>
+public partial class MapRenderer : Node2D
+{
+    public MapData? Map { get; set; }
+    public int TileSize { get; set; } = 16;
+
+    public override void _Ready()
+    {
+        if (Map == null)
+        {
+            GD.Print("MapRenderer has no map data to render.");
+        }
+    }
+
+    public override void _Draw()
+    {
+        if (Map == null)
+        {
+            return;
+        }
+
+        for (int y = 0; y < Map.Height; y++)
+        {
+            for (int x = 0; x < Map.Width; x++)
+            {
+                var tile = Map[x, y];
+                Color color = tile.Tag == "Wall" ? Colors.Gray : Colors.White;
+                DrawRect(new Rect2(x * TileSize, y * TileSize, TileSize, TileSize), color);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement TaggingSystem to manage affinities and antagonisms
- stub WfcService for initial Wave Function Collapse generation
- introduce MapData structures for storing grid tiles
- add Godot MapRenderer for drawing generated maps

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b316c95774832f9d3f811324b94597