### PR TITLE
Add decision and task tracking docs

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,12 @@
+# Decision Log
+
+Record significant project decisions and their context.
+
+## Template
+
+- **Date:** YYYY-MM-DD
+- **Decision:** Summary of the choice made.
+- **Rationale:** Why this decision was made.
+- **Impacted Components:** Areas of the codebase or documentation affected.
+
+Add new entries below this template.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Open the project in the Godot editor. The main scene should run without errors.
 All development must follow the detailed specifications and workflows outlined in the official project plan.
 
 ➡️ Read the plan.md file before making any changes.
+➡️ Review [DECISIONS.md](DECISIONS.md) for logged decisions and [TASKS.md](TASKS.md) for active work.
 
 Key Development Rules (MANDATORY)
 The Single Path Rule: Never create a parallel system for something that already exists. Extend, modify, or replace—do not duplicate.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,5 @@
+# Task Tracker
+
+| Task Description | Status | Assignee | References |
+|------------------|--------|----------|------------|
+|                  |        |          |            |


### PR DESCRIPTION
## Summary
- add DECISIONS.md for recording project decisions
- add TASKS.md for tracking work items
- link decision and task logs from README

## Testing
- `dotnet build` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b316ca9918832fbd634e93da7d88cc