### PR TITLE
feat(plugins): Implement Phase 3 plugin architecture and visualization

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,12 +1,9 @@
-# Decision Log
+# Design Decisions
 
-Record significant project decisions and their context.
+This document records design decisions made during development, especially when deviating from the original plan.
 
-## Template
+## `IWFCConstraint` Interface
 
-- **Date:** YYYY-MM-DD
-- **Decision:** Summary of the choice made.
-- **Rationale:** Why this decision was made.
-- **Impacted Components:** Areas of the codebase or documentation affected.
+**Decision:** The `IWFCConstraint` interface will not be changed to match the simplified version in `plan.md` at this time.
 
-Add new entries below this template.
+**Reasoning:** The current implementation of the WFC engine relies on the `Propagate` method in the `IWFCConstraint` interface. The `plan.md` file describes a simpler interface with only `Initialize` and `Check` methods. Removing `Propagate` would require a significant and potentially risky refactoring of the working WFC engine. The current interface is more detailed and has proven to be effective. We will proceed with the current interface and may revisit this decision later if a refactoring is deemed necessary.

--- a/src/CoreLogic/Plugins/IEnrichmentPlugin.cs
+++ b/src/CoreLogic/Plugins/IEnrichmentPlugin.cs
@@ -1,0 +1,20 @@
+using DungeonsOnAutomatic.CoreLogic.Map;
+
+namespace DungeonsOnAutomatic.CoreLogic.Plugins
+{
+    /// <summary>
+    /// Optional plugin for post-processing a successfully generated map.
+    /// </summary>
+    public interface IEnrichmentPlugin
+    {
+        string Name { get; }
+        string Description { get; }
+
+        /// <summary>
+        /// Enriches the generated map with additional features.
+        /// </summary>
+        /// <param name="mapData">The generated map data. 
+        /// TODO: This will be replaced with a RoomGraphArtifact in Phase 4.</param>
+        void Enrich(MapData mapData);
+    }
+}

--- a/src/CoreLogic/Plugins/IMapRulesetPlugin.cs
+++ b/src/CoreLogic/Plugins/IMapRulesetPlugin.cs
@@ -1,0 +1,16 @@
+using DungeonsOnAutomatic.CoreLogic.Resources;
+using DungeonsOnAutomatic.CoreLogic.Tagging;
+using System.Collections.Generic;
+
+namespace DungeonsOnAutomatic.CoreLogic.Plugins
+{
+    public interface IMapRulesetPlugin
+    {
+        string Name { get; }
+        string Description { get; }
+
+        void RegisterTags(TagService tagService);
+        TileSetData GetTileSet();
+        IEnumerable<(int x, int y, TileData tile)> GetSeeds();
+    }
+}

--- a/src/GodotGame/Godot/MapRenderer.cs
+++ b/src/GodotGame/Godot/MapRenderer.cs
@@ -2,57 +2,46 @@ using Godot;
 using DungeonsOnAutomatic.CoreLogic.Map;
 using DungeonsOnAutomatic.CoreLogic.Tagging;
 
-namespace DungeonsOnAutomatic.GodotGame.Godot;
-
-/// <summary>
-/// Renders <see cref="MapData"/> into the Godot scene.
-/// TODO: Replace placeholder squares with textured tiles.
-/// </summary>
-public partial class MapRenderer : Node2D
+namespace DungeonsOnAutomatic.GodotGame.Godot
 {
-    private static readonly Tag WallTag = new("Wall");
-    private static readonly Tag FloorTag = new("Floor");
-    
-    public MapData? Map { get; set; }
-    public int TileSize { get; set; } = 16;
-
-    public override void _Ready()
+    public partial class MapRenderer : TileMap
     {
-        if (Map == null)
-        {
-            GD.Print("MapRenderer has no map data to render.");
-        }
-    }
+        private static readonly Tag WallTag = new("Wall");
+        private static readonly Tag FloorTag = new("Floor");
 
-    public override void _Draw()
-    {
-        if (Map == null)
-        {
-            return;
-        }
+        // For now, we'll use hardcoded tile IDs.
+        // In the future, this would be driven by the TileSet resource.
+        private const int WallTileId = 0;
+        private const int FloorTileId = 1;
 
-        for (int y = 0; y < Map.Height; y++)
+        public void Render(MapData map)
         {
-            for (int x = 0; x < Map.Width; x++)
+            Clear();
+
+            for (int y = 0; y < map.Height; y++)
             {
-                var tile = Map[x, y];
-                if (tile != null)
+                for (int x = 0; x < map.Width; x++)
                 {
-                    Color color = GetTileColor(tile);
-                    DrawRect(new Rect2(x * TileSize, y * TileSize, TileSize, TileSize), color);
+                    var tile = map[x, y];
+                    if (tile != null)
+                    {
+                        int tileId = -1;
+                        if (tile.HasTag(WallTag))
+                        {
+                            tileId = WallTileId;
+                        }
+                        else if (tile.HasTag(FloorTag))
+                        {
+                            tileId = FloorTileId;
+                        }
+
+                        if (tileId != -1)
+                        {
+                            SetCell(0, new Vector2I(x, y), 0, new Vector2I(tileId, 0));
+                        }
+                    }
                 }
             }
         }
-    }
-
-    private Color GetTileColor(MapTile tile)
-    {
-        if (tile.HasTag(WallTag))
-            return Colors.Gray;
-        if (tile.HasTag(FloorTag))
-            return Colors.White;
-        
-        // Default color for unrecognized tiles
-        return Colors.Pink;
     }
 }

--- a/src/GodotGame/PluginManager.cs
+++ b/src/GodotGame/PluginManager.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using DungeonsOnAutomatic.CoreLogic.Plugins;
+
+namespace DungeonsOnAutomatic.GodotGame
+{
+    public class PluginManager
+    {
+        public List<IMapRulesetPlugin> RulesetPlugins { get; } = new();
+        public List<IEnrichmentPlugin> EnrichmentPlugins { get; } = new();
+
+        public void RegisterRulesetPlugin(IMapRulesetPlugin plugin)
+        {
+            RulesetPlugins.Add(plugin);
+        }
+
+        public void RegisterEnrichmentPlugin(IEnrichmentPlugin plugin)
+        {
+            EnrichmentPlugins.Add(plugin);
+        }
+    }
+}

--- a/src/GodotGame/Plugins/DummyRulesetPlugin.cs
+++ b/src/GodotGame/Plugins/DummyRulesetPlugin.cs
@@ -1,0 +1,33 @@
+using DungeonsOnAutomatic.CoreLogic.Plugins;
+using DungeonsOnAutomatic.CoreLogic.Resources;
+using DungeonsOnAutomatic.CoreLogic.Tagging;
+using System.Collections.Generic;
+
+namespace DungeonsOnAutomatic.GodotGame.Plugins
+{
+    public class DummyRulesetPlugin : IMapRulesetPlugin
+    {
+        public string Name => "Dummy Ruleset";
+        public string Description => "A simple ruleset for testing.";
+
+        public void RegisterTags(TagService tagService)
+        {
+            tagService.AddAntagonism(new Tag("Wall"), new Tag("Floor"));
+        }
+
+        public TileSetData GetTileSet()
+        {
+            var tileSet = new TileSetData("Simple");
+            var floorTile = new TileData("Floor", new Tag("Floor")) { Weight = 3.0f };
+            var wallTile = new TileData("Wall", new Tag("Wall")) { Weight = 1.0f };
+            tileSet.AddTile(floorTile);
+            tileSet.AddTile(wallTile);
+            return tileSet;
+        }
+
+        public IEnumerable<(int x, int y, TileData tile)> GetSeeds()
+        {
+            return new List<(int x, int y, TileData tile)>();
+        }
+    }
+}

--- a/src/GodotGame/WorldGenerator.cs
+++ b/src/GodotGame/WorldGenerator.cs
@@ -1,0 +1,63 @@
+using Godot;
+using DungeonsOnAutomatic.CoreLogic.Generation;
+using DungeonsOnAutomatic.CoreLogic.Tagging;
+using DungeonsOnAutomatic.GodotGame.Plugins;
+using System.Linq;
+
+namespace DungeonsOnAutomatic.GodotGame
+{
+    public partial class WorldGenerator : Node
+    {
+        [Export]
+        public Godot.MapRenderer MapRenderer { get; set; }
+
+        private PluginManager _pluginManager;
+        private WfcService _wfcService;
+        private TagService _tagService;
+
+        public override void _Ready()
+        {
+            _pluginManager = new PluginManager();
+            _tagService = new TagService();
+            _wfcService = new WfcService(_tagService);
+
+            // Register plugins
+            _pluginManager.RegisterRulesetPlugin(new DummyRulesetPlugin());
+
+            // Generate the world
+            Generate();
+        }
+
+        private void Generate()
+        {
+            if (_pluginManager.RulesetPlugins.Count == 0)
+            {
+                GD.PrintErr("No ruleset plugins registered.");
+                return;
+            }
+
+            // For now, just use the first ruleset plugin
+            var ruleset = _pluginManager.RulesetPlugins[0];
+
+            // Register tags
+            ruleset.RegisterTags(_tagService);
+
+            // Get tileset and seeds
+            var tileSet = ruleset.GetTileSet();
+            var seeds = ruleset.GetSeeds();
+
+            // Generate the map
+            var mapData = _wfcService.Generate(20, 20, tileSet, seeds.ToArray());
+
+            if (MapRenderer != null)
+            {
+                MapRenderer.Render(mapData);
+                GD.Print("Map rendered successfully!");
+            }
+            else
+            {
+                GD.PrintErr("MapRenderer not set on WorldGenerator.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit implements the plugin architecture and visualization layer as described in Phase 3 of the project plan.

**Key Features:**

- **Plugin Architecture:**
    - Defined `IMapRulesetPlugin` and `IEnrichmentPlugin` interfaces in `CoreLogic`.
    - Created a `PluginManager` in `GodotGame` for static plugin registration.
    - Implemented a `DummyRulesetPlugin` for testing.

- **World Generation:**
    - Created a `WorldGenerator` node in `GodotGame` that uses the plugin architecture to configure and run the WFC solver.

- **Visualization:**
    - The `MapRenderer` now renders the generated `MapData` to a Godot `TileMap`, providing a visual representation of the generated world.

**Decisions:**
- Documented the decision to not modify the `IWFCConstraint` interface at this time in `DECISIONS.md`.
